### PR TITLE
Fix Gateway for request-reponse and request-many

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/ServiceReference.java
+++ b/services-api/src/main/java/io/scalecube/services/ServiceReference.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public class ServiceReference {
 
+  private String qualifier;
   private String endpointId;
   private String host;
   private int port;
@@ -12,6 +13,7 @@ public class ServiceReference {
   private String contentType;
   private Map<String, String> tags;
   private String action;
+  private CommunicationMode mode;
 
   /**
    * @deprecated exposed only for deserialization purpose.
@@ -28,6 +30,8 @@ public class ServiceReference {
     this.contentType = mergeContentType(serviceMethodDefinition, serviceRegistration);
     this.tags = mergeTags(serviceMethodDefinition, serviceRegistration, serviceEndpoint);
     this.action = serviceMethodDefinition.getAction();
+    this.mode = serviceMethodDefinition.getCommunicationMode();
+    this.qualifier = this.namespace + "/" + this.action;
   }
 
   public ServiceReference(String endpointId, String host, int port, String namespace, String contentType,
@@ -39,6 +43,14 @@ public class ServiceReference {
     this.contentType = contentType;
     this.tags = tags;
     this.action = action;
+  }
+
+  public CommunicationMode mode() {
+    return mode;
+  }
+
+  public String qualifier() {
+    return this.qualifier;
   }
 
   public String endpointId() {

--- a/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
@@ -16,7 +16,7 @@ public interface ServiceRegistry {
 
   List<ServiceReference> listServiceReferences();
 
-  List<ServiceReference> lookupService(String namespace);
+  List<ServiceReference> lookupService(String qualifier);
 
   List<ServiceReference> lookupService(Predicate<? super ServiceReference> filter);
 

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
@@ -24,7 +24,9 @@ public final class ServiceMessageDataCodec {
   private static final String DEFAULT_DATA_FORMAT = "application/json";
 
   public ServiceMessage encode(ServiceMessage message) {
-    if (message.hasData()) {
+    if(message.hasData() && message.data() instanceof ByteBuf) {
+     return message; 
+    } else if (message.hasData()) {
       ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
       try {
         String contentType = Optional.ofNullable(message.dataFormat()).orElse(DEFAULT_DATA_FORMAT);

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
@@ -24,7 +24,7 @@ public final class ServiceMessageDataCodec {
   private static final String DEFAULT_DATA_FORMAT = "application/json";
 
   public ServiceMessage encode(ServiceMessage message) {
-    if (message.hasData() && message.data() instanceof ByteBuf) {
+    if (message.hasData(ByteBuf.class)) {
       return message;
     } else if (message.hasData()) {
       ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
@@ -24,8 +24,8 @@ public final class ServiceMessageDataCodec {
   private static final String DEFAULT_DATA_FORMAT = "application/json";
 
   public ServiceMessage encode(ServiceMessage message) {
-    if(message.hasData() && message.data() instanceof ByteBuf) {
-     return message; 
+    if (message.hasData() && message.data() instanceof ByteBuf) {
+      return message;
     } else if (message.hasData()) {
       ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
       try {
@@ -43,7 +43,7 @@ public final class ServiceMessageDataCodec {
   }
 
   public ServiceMessage decode(ServiceMessage message, Class<?> type) {
-    if (!message.hasData(ByteBuf.class)) {
+    if (!message.hasData(ByteBuf.class) || type == null) {
       return message;
     }
 

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -263,9 +263,9 @@ public class Microservices {
 
   public Call call() {
     Router router = Routers.getRouter(RoundRobinServiceRouter.class);
-    return new ServiceCall(client, serviceHandlers, serviceRegistry).call().metrics(metrics).router(router);
+    return new Call(client, serviceHandlers, serviceRegistry).metrics(metrics).router(router);
   }
-
+  
   public Mono<Void> shutdown() {
     return Mono.when(Mono.fromFuture(cluster.shutdown()), server.stop());
   }

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -229,12 +229,10 @@ public class Reflect {
    * @return the parameterized Type of a given object or Object class if unknown.
    */
   public static Type parameterizedRequestType(Method method) {
-    if (method != null) {
-      if (method.getGenericParameterTypes().length > 0) {
-        Type type = method.getGenericParameterTypes()[0];
-        if (type instanceof ParameterizedType) {
-          return ((ParameterizedType) type).getActualTypeArguments()[0];
-        }
+    if (method != null && method.getGenericParameterTypes().length > 0) {
+      Type type = method.getGenericParameterTypes()[0];
+      if (type instanceof ParameterizedType) {
+        return ((ParameterizedType) type).getActualTypeArguments()[0];
       }
     }
     return Object.class;

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -324,7 +324,10 @@ public class Reflect {
    */
   public static void validateMethodOrThrow(Method method) {
     Class<?> returnType = method.getReturnType();
-    if (!Publisher.class.isAssignableFrom(returnType)) {
+    if (returnType.equals(Void.TYPE)) {
+      return;
+    } else if (!Publisher.class.isAssignableFrom(returnType)) {
+      System.out.println(returnType);
       throw new UnsupportedOperationException("Service method return type can be Publisher only");
     }
     if (method.getParameters().length > 1) {
@@ -334,9 +337,10 @@ public class Reflect {
 
   public static CommunicationMode communicationMode(Method method) {
     Class<?> returnType = method.getReturnType();
-    Class<?> paramType = parameterizedReturnType(method);
-    if (returnType.isAssignableFrom(Mono.class)) {
-      return Void.class.isAssignableFrom(paramType) ? FIRE_AND_FORGET : REQUEST_RESPONSE;
+    if (returnType.isAssignableFrom(Void.TYPE)) {
+      return FIRE_AND_FORGET;
+    } else if (returnType.isAssignableFrom(Mono.class)) {
+      return REQUEST_RESPONSE;
     } else if (returnType.isAssignableFrom(Flux.class)) {
       Class<?>[] reqTypes = method.getParameterTypes();
       boolean hasFluxAsReqParam = reqTypes.length > 0

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -97,7 +97,7 @@ public class Reflect {
                 if (mapper.getType().equals(Microservices.class)) {
                   return this.microservices;
                 } else if (isService(mapper.getType())) {
-                  return this.microservices.call().api(mapper.getType());
+                  return this.microservices.call().create().api(mapper.getType());
                 } else {
                   return null;
                 }
@@ -128,7 +128,7 @@ public class Reflect {
           LOGGER.warn("Unable to inject router {}, using RoundRobin", injection.router());
           return Routers.getRouter(RoundRobinServiceRouter.class);
         });
-        setField(field, service, this.microservices.call().router(router).api(field.getType()));
+        setField(field, service, this.microservices.call().router(router).create().api(field.getType()));
       }
     }
 
@@ -235,6 +235,7 @@ public class Reflect {
         return ((ParameterizedType) type).getActualTypeArguments()[0];
       }
     }
+
     return Object.class;
   }
 

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.TopicProcessor;
+import reactor.core.publisher.UnicastProcessor;
 import reactor.core.publisher.WorkQueueProcessor;
 
 public class ServiceCall {
@@ -194,13 +196,11 @@ public class ServiceCall {
      * @return flux publisher of service responses.
      */
     public Flux<ServiceMessage> invoke(Publisher<ServiceMessage> publisher) {
-      final Processor<ServiceMessage, ServiceMessage> downstream =
-          WorkQueueProcessor.<ServiceMessage>builder().autoCancel(false).build();
+      
       final Processor<ServiceMessage, ServiceMessage> upstream =
-          WorkQueueProcessor.<ServiceMessage>builder().autoCancel(false).build();
-      Flux.from(publisher).subscribe(onNext -> downstream.onNext(onNext));
+          UnicastProcessor.<ServiceMessage>create();
 
-      Flux.from(downstream).subscribe(request -> {
+      Flux.from(publisher).subscribe(request -> {
 
         Messages.validate().serviceRequest(request);
         String qualifier = request.qualifier();

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -20,7 +20,6 @@ import io.scalecube.services.transport.LocalServiceHandlers;
 import io.scalecube.services.transport.client.api.ClientTransport;
 import io.scalecube.transport.Address;
 
-import com.codahale.metrics.Timer;
 import com.google.common.reflect.Reflection;
 
 import org.reactivestreams.Processor;

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -283,10 +283,12 @@ public class ServiceCall {
             .requestBidirectional(Flux.just(request)))
             .map(message -> dataCodec.encode(message))
             .subscribe(next -> upstream.onNext(next));
+
       } else if (mode.equals(FIRE_AND_FORGET)) {
         Flux.from(transport.create(address)
             .requestBidirectional(Flux.just(request)).as(Mono::from))
             .then();
+
       } else if (mode.equals(REQUEST_CHANNEL)) {
         throw new IllegalArgumentException("Communication mode is not supported: " + request.qualifier());
       }

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -39,30 +39,27 @@ public class ServiceCall {
   private final ClientTransport transport;
   private final LocalServiceHandlers serviceHandlers;
   private final ServiceRegistry serviceRegistry;
+  private final Router router;
+  private final Metrics metrics;
+  private final ServiceMessageDataCodec dataCodec = new ServiceMessageDataCodec();
 
-  public ServiceCall(ClientTransport transport,
-      LocalServiceHandlers serviceHandlers,
-      ServiceRegistry serviceRegistry) {
-    this.transport = transport;
-    this.serviceHandlers = serviceHandlers;
-    this.serviceRegistry = serviceRegistry;
-  }
-
-  public Call call() {
-    return new Call(this.transport, this.serviceHandlers, this.serviceRegistry);
+  ServiceCall(Call call) {
+    this.transport = call.transport;
+    this.serviceHandlers = call.serviceHandlers;
+    this.serviceRegistry = call.serviceRegistry;
+    this.router = call.router;
+    this.metrics = call.metrics;
   }
 
   public static class Call {
 
     private Router router;
     private Metrics metrics;
-    private Timer latency;
 
     private final ClientTransport transport;
     private final LocalServiceHandlers serviceHandlers;
     private final ServiceRegistry serviceRegistry;
 
-    private final ServiceMessageDataCodec dataCodec = new ServiceMessageDataCodec();
 
     public Call(ClientTransport transport, LocalServiceHandlers serviceHandlers, ServiceRegistry serviceRegistry) {
       this.transport = transport;
@@ -82,236 +79,262 @@ public class ServiceCall {
 
     public Call metrics(Metrics metrics) {
       this.metrics = metrics;
-      this.latency = Metrics.timer(this.metrics, ServiceCall.class.getName(), "invoke");
       return this;
     }
 
-    /**
-     * Issues fire-and-rorget request.
-     *
-     * @param request request message to send.
-     * @return mono publisher completing normally or with error.
-     */
-    public Mono<Void> oneWay(ServiceMessage request) {
-      return requestOne(request, Void.class).then();
+    public ServiceCall create() {
+      return new ServiceCall(this);
     }
 
-    /**
-     * Issues request-and-reply request.
-     *
-     * @param request request message to send.
-     * @return mono publisher completing with single response message or with error.
-     */
-    public Mono<ServiceMessage> requestOne(ServiceMessage request) {
-      return requestBidirectional(Mono.just(request)).as(Mono::from);
-    }
+  }
 
-    /**
-     * Issues request-and-reply request.
-     *
-     * @param request request message to send.
-     * @param responseType type of response.
-     * @return mono publisher completing with single response message or with error.
-     */
-    public Mono<ServiceMessage> requestOne(ServiceMessage request, Class<?> responseType) {
-      return requestBidirectional(Mono.just(request), responseType).as(Mono::from);
-    }
+  /**
+   * Issues fire-and-rorget request.
+   *
+   * @param request request message to send.
+   * @return mono publisher completing normally or with error.
+   */
+  public Mono<Void> oneWay(ServiceMessage request) {
+    return requestOne(request, Void.class).then();
+  }
 
-    /**
-     * Issues request to service which returns stream of service messages back.
-     *
-     * @param request request message to send.
-     * @return todo
-     */
-    public Flux<ServiceMessage> requestMany(ServiceMessage request) {
-      return requestBidirectional(Mono.just(request));
-    }
+  /**
+   * Issues request-and-reply request.
+   *
+   * @param request request message to send.
+   * @return mono publisher completing with single response message or with error.
+   */
+  public Mono<ServiceMessage> requestOne(ServiceMessage request) {
+    return requestBidirectional(Mono.just(request)).as(Mono::from);
+  }
 
-    /**
-     * Issues request to service which returns stream of service messages back.
-     *
-     * @param request request with given headers.
-     * @param responseType type of responses.
-     * @return todo
-     */
-    public Flux<ServiceMessage> requestMany(ServiceMessage request, Class<?> responseType) {
-      return requestBidirectional(Mono.just(request), responseType);
-    }
+  /**
+   * Issues request-and-reply request.
+   *
+   * @param request request message to send.
+   * @param responseType type of response.
+   * @return mono publisher completing with single response message or with error.
+   */
+  public Mono<ServiceMessage> requestOne(ServiceMessage request, Class<?> responseType) {
+    return requestBidirectional(Mono.just(request), responseType).as(Mono::from);
+  }
 
-    /**
-     * todo
-     * 
-     * @param publisher
-     * @return
-     */
-    public Flux<ServiceMessage> requestBidirectional(Publisher<ServiceMessage> publisher) {
-      return requestBidirectional(publisher, null);
-    }
+  /**
+   * Issues request to service which returns stream of service messages back.
+   *
+   * @param request request message to send.
+   * @return stream of service responses.
+   */
+  public Flux<ServiceMessage> requestMany(ServiceMessage request) {
+    return requestBidirectional(Mono.just(request));
+  }
 
-    /**
-     * todo
-     * 
-     * @param publisher
-     * @param responseType type of responses.
-     * @return
-     */
-    public Flux<ServiceMessage> requestBidirectional(Publisher<ServiceMessage> publisher, Class<?> responseType) {
-      return Flux.from(HeadAndTail.createFrom(publisher)).flatMap(pair -> {
+  /**
+   * Issues request to service which returns stream of service messages back.
+   *
+   * @param request request with given headers.
+   * @param responseType type of responses.
+   * @return stream of service responses.
+   */
+  public Flux<ServiceMessage> requestMany(ServiceMessage request, Class<?> responseType) {
+    return requestBidirectional(Mono.just(request), responseType);
+  }
 
-        ServiceMessage request = pair.head();
-        Flux<ServiceMessage> requestPublisher = Flux.from(pair.tail()).startWith(request);
+  /**
+   * Issues stream of service requests to service which returns stream of service messages back.
+   * 
+   * @param stream of service requests.
+   * @return stream of service responses.
+   */
+  public Flux<ServiceMessage> requestBidirectional(Publisher<ServiceMessage> publisher) {
+    return requestBidirectional(publisher, null);
+  }
 
-        Messages.validate().serviceRequest(request);
-        String qualifier = request.qualifier();
+  /**
+   * Issues stream of service requests to service which returns stream of service messages back.
+   * 
+   * @param stream of service requests.
+   * @param responseType type of responses.
+   * @return stream of service responses.
+   */
+  public Flux<ServiceMessage> requestBidirectional(Publisher<ServiceMessage> publisher, Class<?> responseType) {
+    return Flux.from(HeadAndTail.createFrom(publisher)).flatMap(pair -> {
 
-        if (serviceHandlers.contains(qualifier)) {
-          ServiceMessageHandler serviceHandler = serviceHandlers.get(qualifier);
-          return serviceHandler.invoke(requestPublisher).onErrorMap(ExceptionProcessor::mapException);
-        } else {
+      ServiceMessage request = pair.head();
+      Flux<ServiceMessage> requestPublisher = Flux.from(pair.tail()).startWith(request);
 
-          ServiceReference serviceReference =
-              router.route(serviceRegistry, request)
-                  .orElseThrow(() -> noReachableMemberException(request));
+      Messages.validate().serviceRequest(request);
+      String qualifier = request.qualifier();
 
-          Address address =
-              Address.create(serviceReference.host(), serviceReference.port());
-
-          Flux<ServiceMessage> responsePublisher =
-              transport.create(address).requestBidirectional(requestPublisher);
-
-          return responseType == null
-              ? responsePublisher
-              : responsePublisher.map(message -> dataCodec.decode(message, responseType));
-        }
-      });
-    }
-
-    /**
-     * Issues bidirectional request channel communication.
-     * 
-     * @param publisher of service requests.
-     * @param responseType type of responses.
-     * @return flux publisher of service responses.
-     */
-    public Flux<ServiceMessage> invoke(Publisher<ServiceMessage> publisher) {
-
-      final Processor<ServiceMessage, ServiceMessage> upstream =
-          UnicastProcessor.<ServiceMessage>create();
-
-      Flux.from(publisher).subscribe(request -> {
-
-        Messages.validate().serviceRequest(request);
-        String qualifier = request.qualifier();
-
-        if (serviceHandlers.contains(qualifier)) {
-          ServiceMessageHandler serviceHandler = serviceHandlers.get(qualifier);
-          Flux.from(serviceHandler
-              .invoke(Flux.from(publisher))
-              .onErrorMap(ExceptionProcessor::mapException))
-              .subscribe(upstream::onNext);
-        } else {
-          ServiceReference serviceReference =
-              router.route(serviceRegistry, request)
-                  .orElseThrow(() -> noReachableMemberException(request));
-
-          sendMessage(request, serviceReference.mode(),
-              Address.create(serviceReference.host(), serviceReference.port()))
-                  .subscribe(upstream::onNext);
-        }
-      });
-
-      return Flux.from(upstream);
-    }
-
-    /**
-     * Create proxy creates a java generic proxy instance by a given service interface.
-     *
-     * @param serviceInterface Service Interface type.
-     * @return newly created service proxy object.
-     */
-    public <T> T api(Class<T> serviceInterface) {
-
-      final Call serviceCall = this;
-
-      return Reflection.newProxy(serviceInterface, (proxy, method, args) -> {
-
-        Object check = objectToStringEqualsHashCode(method.getName(), serviceInterface, args);
-        if (check != null) {
-          return check; // toString, hashCode was invoked.
-        }
-
-        Metrics.mark(serviceInterface, metrics, method, "request");
-        Class<?> parameterizedReturnType = Reflect.parameterizedReturnType(method);
-        CommunicationMode mode = Reflect.communicationMode(method);
-
-        ServiceMessage request = ServiceMessage.builder()
-            .qualifier(Reflect.serviceName(serviceInterface), method.getName())
-            .data(method.getParameterCount() != 0 ? args[0] : NullData.NULL_DATA)
-            .build();
-
-        switch (mode) {
-          case FIRE_AND_FORGET:
-            return serviceCall.oneWay(request);
-          case REQUEST_RESPONSE:
-            return serviceCall.requestOne(request, parameterizedReturnType)
-                .transform(mono -> parameterizedReturnType.equals(ServiceMessage.class) ? mono
-                    : mono.map(ServiceMessage::data));
-          case REQUEST_STREAM:
-            return serviceCall.requestMany(request, parameterizedReturnType)
-                .transform(flux -> parameterizedReturnType.equals(ServiceMessage.class) ? flux
-                    : flux.map(ServiceMessage::data));
-          case REQUEST_CHANNEL:
-            // falls to default
-          default:
-            throw new IllegalArgumentException("Communication mode is not supported: " + method);
-        }
-      });
-    }
-
-    private Flux<ServiceMessage> sendMessage(ServiceMessage request, CommunicationMode mode, Address address) {
-      final Processor<ServiceMessage, ServiceMessage> upstream =
-          UnicastProcessor.<ServiceMessage>create();
-
-      if (mode.equals(REQUEST_RESPONSE)) {
-        Flux.from(transport.create(address)
-            .requestBidirectional(Flux.just(request)).as(Mono::from))
-            .map(message -> dataCodec.encode(message))
-            .subscribe(next -> upstream.onNext(next));
-
-      } else if (mode.equals(REQUEST_STREAM)) {
-        Flux.from(transport.create(address)
-            .requestBidirectional(Flux.just(request)))
-            .map(message -> dataCodec.encode(message))
-            .subscribe(next -> upstream.onNext(next));
-
-      } else if (mode.equals(FIRE_AND_FORGET)) {
-        Flux.from(transport.create(address)
-            .requestBidirectional(Flux.just(request)).as(Mono::from))
-            .then();
-
-      } else if (mode.equals(REQUEST_CHANNEL)) {
-        throw new IllegalArgumentException("Communication mode is not supported: " + request.qualifier());
-      }
-      return Flux.from(upstream);
-    }
-
-
-    private static ServiceUnavailableException noReachableMemberException(ServiceMessage request) {
-      LOGGER.error("Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
-          request.qualifier(), request);
-      return new ServiceUnavailableException("No reachable member with such service: " + request.qualifier());
-    }
-
-    private static Object objectToStringEqualsHashCode(String method, Class<?> serviceInterface, Object... args) {
-      if ("hashCode".equals(method)) {
-        return serviceInterface.hashCode();
-      } else if ("equals".equals(method)) {
-        return serviceInterface.equals(args[0]);
-      } else if ("toString".equals(method)) {
-        return serviceInterface.toString();
+      if (serviceHandlers.contains(qualifier)) {
+        ServiceMessageHandler serviceHandler = serviceHandlers.get(qualifier);
+        return serviceHandler.invoke(requestPublisher).onErrorMap(ExceptionProcessor::mapException);
       } else {
-        return null;
+
+        ServiceReference serviceReference =
+            router.route(serviceRegistry, request)
+                .orElseThrow(() -> noReachableMemberException(request));
+
+        Address address =
+            Address.create(serviceReference.host(), serviceReference.port());
+
+        Flux<ServiceMessage> responsePublisher =
+            transport.create(address).requestBidirectional(requestPublisher);
+
+        return responsePublisher.map(message -> dataCodec.decode(message, responseType));
       }
+    });
+  }
+
+  /**
+   * Issues service request for each service message of the given stream for each message find a service endpoint and
+   * invoke the request according the target endpoint mode.
+   * 
+   * @param publisher of service requests.
+   * @return flux publisher of service responses no encoding is applied.
+   */
+  public Flux<ServiceMessage> invoke(Publisher<ServiceMessage> publisher) {
+    return this.invoke(publisher, null);
+  }
+
+  /**
+   * Issues service request for each service message of the given stream for each message find a service endpoint and
+   * invoke the request according the target end-point type/mode. in case local handlers contains given end-point they
+   * will be preferred over remote end-point.
+   * 
+   * @param publisher of service requests.
+   * @param responseType type of responses.
+   * @return flux publisher of service responses decoded by a given responseType.
+   */
+  public Flux<ServiceMessage> invoke(Publisher<ServiceMessage> publisher, Class<?> responseType) {
+
+    final Processor<ServiceMessage, ServiceMessage> upstream =
+        UnicastProcessor.<ServiceMessage>create();
+
+    Flux.from(publisher).subscribe(request -> {
+
+      Messages.validate().serviceRequest(request);
+      String qualifier = request.qualifier();
+
+      if (serviceHandlers.contains(qualifier)) {
+        ServiceMessageHandler serviceHandler = serviceHandlers.get(qualifier);
+        Flux.from(serviceHandler
+            .invoke(Flux.from(publisher))
+            .onErrorMap(ExceptionProcessor::mapException))
+            .subscribe(upstream::onNext);
+      } else {
+        ServiceReference serviceReference =
+            router.route(serviceRegistry, request)
+                .orElseThrow(() -> noReachableMemberException(request));
+
+        invoke(request, serviceReference.mode(),
+            Address.create(serviceReference.host(), serviceReference.port()))
+                .map(message -> dataCodec.decode(message, responseType))
+                .subscribe(upstream::onNext);
+      }
+    });
+
+    return Flux.from(upstream);
+  }
+
+  /**
+   * Invoke remote service end-point with a given Address and mode of invocation.
+   * 
+   * @param request to invoke remote.
+   * @param mode and style of desired invocation.
+   * @param address of the target end-point.
+   * @return flux publisher of service responses no encoding is applied.
+   */
+  public Flux<ServiceMessage> invoke(ServiceMessage request, CommunicationMode mode, Address address) {
+
+    final Processor<ServiceMessage, ServiceMessage> upstream =
+        UnicastProcessor.<ServiceMessage>create();
+
+    if (mode.equals(REQUEST_RESPONSE)) {
+      Flux.from(transport.create(address)
+          .requestBidirectional(Flux.just(request)).as(Mono::from))
+          .map(message -> dataCodec.encode(message))
+          .subscribe(next -> upstream.onNext(next));
+
+    } else if (mode.equals(REQUEST_STREAM)) {
+      Flux.from(transport.create(address)
+          .requestBidirectional(Flux.just(request)))
+          .map(message -> dataCodec.encode(message))
+          .subscribe(next -> upstream.onNext(next));
+
+    } else if (mode.equals(FIRE_AND_FORGET)) {
+      Flux.from(transport.create(address)
+          .requestBidirectional(Flux.just(request)).as(Mono::from))
+          .then();
+
+    } else if (mode.equals(REQUEST_CHANNEL)) {
+      throw new IllegalArgumentException("Communication mode is not supported: " + request.qualifier());
+    }
+    return Flux.from(upstream);
+  }
+
+  /**
+   * Create proxy creates a java generic proxy instance by a given service interface.
+   *
+   * @param serviceInterface Service Interface type.
+   * @return newly created service proxy object.
+   */
+  public <T> T api(Class<T> serviceInterface) {
+
+    final ServiceCall serviceCall = this;
+
+    return Reflection.newProxy(serviceInterface, (proxy, method, args) -> {
+
+      Object check = objectToStringEqualsHashCode(method.getName(), serviceInterface, args);
+      if (check != null) {
+        return check; // toString, hashCode was invoked.
+      }
+
+      Metrics.mark(serviceInterface, metrics, method, "request");
+      Class<?> parameterizedReturnType = Reflect.parameterizedReturnType(method);
+      CommunicationMode mode = Reflect.communicationMode(method);
+
+      ServiceMessage request = ServiceMessage.builder()
+          .qualifier(Reflect.serviceName(serviceInterface), method.getName())
+          .data(method.getParameterCount() != 0 ? args[0] : NullData.NULL_DATA)
+          .build();
+
+      switch (mode) {
+        case FIRE_AND_FORGET:
+          return serviceCall.oneWay(request);
+        case REQUEST_RESPONSE:
+          return serviceCall.requestOne(request, parameterizedReturnType)
+              .transform(mono -> parameterizedReturnType.equals(ServiceMessage.class) ? mono
+                  : mono.map(ServiceMessage::data));
+        case REQUEST_STREAM:
+          return serviceCall.requestMany(request, parameterizedReturnType)
+              .transform(flux -> parameterizedReturnType.equals(ServiceMessage.class) ? flux
+                  : flux.map(ServiceMessage::data));
+        case REQUEST_CHANNEL:
+          // falls to default
+        default:
+          throw new IllegalArgumentException("Communication mode is not supported: " + method);
+      }
+    });
+  }
+
+
+
+  private static ServiceUnavailableException noReachableMemberException(ServiceMessage request) {
+    LOGGER.error("Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
+        request.qualifier(), request);
+    return new ServiceUnavailableException("No reachable member with such service: " + request.qualifier());
+  }
+
+  private static Object objectToStringEqualsHashCode(String method, Class<?> serviceInterface, Object... args) {
+    if ("hashCode".equals(method)) {
+      return serviceInterface.hashCode();
+    } else if ("equals".equals(method)) {
+      return serviceInterface.equals(args[0]);
+    } else if ("toString".equals(method)) {
+      return serviceInterface.toString();
+    } else {
+      return null;
     }
   }
 }

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -303,11 +303,11 @@ public class ServiceCall {
     }
 
     private static Object objectToStringEqualsHashCode(String method, Class<?> serviceInterface, Object... args) {
-      if (method.equals("hashCode")) {
+      if ("hashCode".equals(method)) {
         return serviceInterface.hashCode();
-      } else if (method.equals("equals")) {
+      } else if ("equals".equals(method)) {
         return serviceInterface.equals(args[0]);
-      } else if (method.equals("toString")) {
+      } else if ("toString".equals(method)) {
         return serviceInterface.toString();
       } else {
         return null;

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -218,7 +218,7 @@ public class ServiceCall {
       if (serviceHandlers.contains(qualifier)) {
         ServiceMessageHandler serviceHandler = serviceHandlers.get(qualifier);
         Flux.from(serviceHandler
-            .invoke(Flux.from(publisher))
+            .invoke(Flux.just(request))
             .onErrorMap(ExceptionProcessor::mapException))
             .subscribe(upstream::onNext);
       } else {

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -30,9 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.TopicProcessor;
 import reactor.core.publisher.UnicastProcessor;
-import reactor.core.publisher.WorkQueueProcessor;
 
 public class ServiceCall {
 
@@ -196,7 +194,7 @@ public class ServiceCall {
      * @return flux publisher of service responses.
      */
     public Flux<ServiceMessage> invoke(Publisher<ServiceMessage> publisher) {
-      
+
       final Processor<ServiceMessage, ServiceMessage> upstream =
           UnicastProcessor.<ServiceMessage>create();
 

--- a/services/src/main/java/io/scalecube/services/discovery/ServiceDiscovery.java
+++ b/services/src/main/java/io/scalecube/services/discovery/ServiceDiscovery.java
@@ -45,8 +45,6 @@ public class ServiceDiscovery {
         loadMemberServices(DiscoveryType.REMOVED, event.member());
       }
     });
-    // ThreadFactory.singleScheduledExecutorService("service-registry-discovery")
-    // .scheduleAtFixedRate(this::loadClusterServices, 10, 10, TimeUnit.SECONDS);
   }
 
   private void loadClusterServices(Cluster cluster) {
@@ -65,16 +63,18 @@ public class ServiceDiscovery {
           }
 
           LOGGER.debug("Member: {} is {} : {}", member, type, serviceEndpoint);
-          if (type.equals(DiscoveryType.ADDED) || type.equals(DiscoveryType.DISCOVERED)) {
-            if (serviceRegistry.registerService(serviceEndpoint)) {
-              LOGGER.info("Service Reference was ADDED since new Member has joined the cluster {} : {}",
-                  member, serviceEndpoint);
-            }
-          } else if (type.equals(DiscoveryType.REMOVED)) {
-            if (serviceRegistry.unregisterService(serviceEndpoint.id()) != null) {
-              LOGGER.info("Service Reference was REMOVED since Member have left the cluster {} : {}",
-                  member, serviceEndpoint);
-            }
+          if ((type.equals(DiscoveryType.ADDED) || type.equals(DiscoveryType.DISCOVERED))
+              && (serviceRegistry.registerService(serviceEndpoint))) {
+
+            LOGGER.info("Service Reference was ADDED since new Member has joined the cluster {} : {}",
+                member, serviceEndpoint);
+
+          } else if (type.equals(DiscoveryType.REMOVED)
+              && (serviceRegistry.unregisterService(serviceEndpoint.id()) != null)) {
+
+            LOGGER.info("Service Reference was REMOVED since Member have left the cluster {} : {}",
+                member, serviceEndpoint);
+
           }
         });
   }

--- a/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
@@ -28,7 +28,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 
   @Override
   public List<ServiceReference> lookupService(String qualifier) {
-    return lookupService(r -> r.qualifier().equalsIgnoreCase(qualifier));
+    return lookupService(sref -> sref.qualifier().equalsIgnoreCase(qualifier));
   }
 
   @Override

--- a/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
@@ -27,8 +27,8 @@ public class ServiceRegistryImpl implements ServiceRegistry {
   }
 
   @Override
-  public List<ServiceReference> lookupService(String namespace) {
-    return lookupService(r -> namespace.equalsIgnoreCase(r.namespace()));
+  public List<ServiceReference> lookupService(String qualifier) {
+    return lookupService(r -> r.qualifier().equalsIgnoreCase(qualifier));
   }
 
   @Override

--- a/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
@@ -25,11 +25,12 @@ public class RoundRobinServiceRouter implements Router {
   public Optional<ServiceReference> route(ServiceRegistry serviceRegistry, ServiceMessage request) {
 
     String serviceName = Messages.qualifierOf(request).getNamespace();
-    String methodName = Messages.qualifierOf(request).getAction();
 
     System.out.println(serviceRegistry.listServiceReferences());
+
     List<ServiceReference> serviceInstances =
-        routes(serviceRegistry, request).stream().filter(sr -> methodName.equalsIgnoreCase(sr.action()))
+        routes(serviceRegistry, request).stream()
+            .filter(sr -> sr.qualifier().equalsIgnoreCase(request.qualifier()))
             .collect(Collectors.toList());
 
     if (serviceInstances.size() > 1) {
@@ -47,7 +48,7 @@ public class RoundRobinServiceRouter implements Router {
 
   @Override
   public List<ServiceReference> routes(ServiceRegistry serviceRegistry, ServiceMessage request) {
-    return serviceRegistry.lookupService(Messages.qualifierOf(request).getNamespace());
+    return serviceRegistry.lookupService(request.qualifier());
   }
 
 }

--- a/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
@@ -38,7 +38,7 @@ public class CoarseGrainedServiceImpl implements CoarseGrainedService {
 
   @Override
   public Mono<String> callGreetingWithDispatcher(String request) {
-    return Mono.from(microservices.call().requestOne(Messages.builder().request(SERVICE_NAME, "greeting")
+    return Mono.from(microservices.call().create().requestOne(Messages.builder().request(SERVICE_NAME, "greeting")
         .data("joe").build()))
         .map(ServiceMessage::data);
   }

--- a/services/src/test/java/io/scalecube/services/ErrorFlowTest.java
+++ b/services/src/test/java/io/scalecube/services/ErrorFlowTest.java
@@ -44,28 +44,28 @@ public class ErrorFlowTest {
   @Test(expected = BadRequestException.class)
   public void testCorruptedRequest() {
     Publisher<ServiceMessage> req = consumer
-        .call().requestOne(TestRequests.GREETING_CORRUPTED_PAYLOAD_REQUEST, GreetingResponse.class);
+        .call().create().requestOne(TestRequests.GREETING_CORRUPTED_PAYLOAD_REQUEST, GreetingResponse.class);
     from(req).block();
   }
 
   @Test(expected = UnauthorizedException.class)
   public void testNotAuthorized() {
     Publisher<ServiceMessage> req = consumer
-        .call().requestOne(TestRequests.GREETING_UNAUTHORIZED_REQUEST, GreetingResponse.class);
+        .call().create().requestOne(TestRequests.GREETING_UNAUTHORIZED_REQUEST, GreetingResponse.class);
     from(req).block();
   }
 
   @Test(expected = BadRequestException.class)
   public void testNullRequestPayload() {
     Publisher<ServiceMessage> req = consumer
-        .call().requestOne(TestRequests.GREETING_NULL_PAYLOAD, GreetingResponse.class);
+        .call().create().requestOne(TestRequests.GREETING_NULL_PAYLOAD, GreetingResponse.class);
     from(req).block();
   }
 
   @Test(expected = ServiceUnavailableException.class)
   public void testServiceUnavailable() {
     Publisher<ServiceMessage> req = consumer
-        .call().requestOne(TestRequests.NOT_FOUND_REQ);
+        .call().create().requestOne(TestRequests.NOT_FOUND_REQ);
     from(req).block();
   }
 }

--- a/services/src/test/java/io/scalecube/services/GracefulShutdownTest.java
+++ b/services/src/test/java/io/scalecube/services/GracefulShutdownTest.java
@@ -48,7 +48,7 @@ public class GracefulShutdownTest extends BaseTest {
     while (members.gateway().cluster().member(members.node1().cluster().address()).isPresent()
         || postShutdown.get() >= 0) {
       
-      Mono<ServiceMessage> future = Mono.from(service.requestOne(request,GreetingResponse.class));
+      Mono<ServiceMessage> future = Mono.from(service.create().requestOne(request,GreetingResponse.class));
       future.subscribe(result->{
      // print the greeting.
         assertThat(result.data(), instanceOf(GreetingResponse.class));

--- a/services/src/test/java/io/scalecube/services/GreetingService.java
+++ b/services/src/test/java/io/scalecube/services/GreetingService.java
@@ -10,6 +10,9 @@ import reactor.core.publisher.Mono;
 interface GreetingService {
 
   @ServiceMethod
+  void notifyGreeting();
+
+  @ServiceMethod
   Mono<String> greetingNoParams();
 
   @ServiceMethod

--- a/services/src/test/java/io/scalecube/services/GreetingServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/GreetingServiceImpl.java
@@ -98,10 +98,17 @@ public final class GreetingServiceImpl implements GreetingService {
     throw new IllegalArgumentException(request.toString());
   }
 
+  @Override
+  public void notifyGreeting() {
+    print("[notifyGreeting] Hello... i am a service and i just notefied");
+  }
+
   private void print(String message) {
     if (!ci) {
       System.out.println(message);
     }
 
   }
+
+
 }

--- a/services/src/test/java/io/scalecube/services/LocalServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/LocalServiceTest.java
@@ -34,7 +34,7 @@ public class LocalServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = node1.call().api(GreetingService.class);
+    GreetingService service = node1.call().create().api(GreetingService.class);
 
     // call the service.
     Mono<GreetingResponse> result =
@@ -108,7 +108,7 @@ public class LocalServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = node1.call().api(GreetingService.class);
+    GreetingService service = node1.call().create().api(GreetingService.class);
 
     CountDownLatch exectOne = new CountDownLatch(1);
     // call the service.
@@ -132,7 +132,7 @@ public class LocalServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = node1.call().api(GreetingService.class);
+    GreetingService service = node1.call().create().api(GreetingService.class);
 
     // call the service.
     GreetingRequest request = new GreetingRequest("joe");
@@ -153,7 +153,7 @@ public class LocalServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = node1.call().api(GreetingService.class);
+    GreetingService service = node1.call().create().api(GreetingService.class);
 
     // call the service.
     GreetingRequest request = new GreetingRequest("joe");
@@ -203,7 +203,7 @@ public class LocalServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = node1.call().api(GreetingService.class);
+    GreetingService service = node1.call().create().api(GreetingService.class);
 
     // call the service.
 
@@ -243,7 +243,7 @@ public class LocalServiceTest extends BaseTest {
   }
 
   private GreetingService createProxy(Microservices gateway) {
-    return gateway.call().api(GreetingService.class); // create proxy for GreetingService API
+    return gateway.call().create().api(GreetingService.class); // create proxy for GreetingService API
   }
 
   private boolean await(CountDownLatch timeLatch, long timeout, TimeUnit timeUnit) throws Exception {

--- a/services/src/test/java/io/scalecube/services/ReflectTest.java
+++ b/services/src/test/java/io/scalecube/services/ReflectTest.java
@@ -23,6 +23,7 @@ public class ReflectTest {
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {"fireAndForget", FIRE_AND_FORGET},
+        {"emptyResponse", REQUEST_RESPONSE},
         {"requestResponse", REQUEST_RESPONSE},
         {"requestStream", REQUEST_STREAM},
         {"requestChannel", REQUEST_CHANNEL},
@@ -49,8 +50,10 @@ public class ReflectTest {
   }
 
   private interface TestService {
-    Mono<Void> fireAndForget(Integer i);
-
+    void fireAndForget(Integer i);
+    
+    Mono<Void> emptyResponse(Integer i);
+    
     Mono<Integer> requestResponse(Integer i);
 
     Flux<Integer> requestStream(Integer i);

--- a/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
@@ -58,6 +58,7 @@ public class RemoteServiceTest extends BaseTest {
 
     CanaryService service = gateway.call()
         .router(Routers.getRouter(CanaryTestingRouter.class))
+        .create()
         .api(CanaryService.class);
 
     Util.sleep(1000);
@@ -98,7 +99,7 @@ public class RemoteServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = gateway.call()
+    GreetingService service = gateway.call().create()
         .api(GreetingService.class);
 
     // call the service.
@@ -123,7 +124,7 @@ public class RemoteServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = gateway.call()
+    GreetingService service = gateway.call().create()
         .api(GreetingService.class);
 
     // call the service.
@@ -152,7 +153,7 @@ public class RemoteServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = gateway.call()
+    GreetingService service = gateway.call().create()
         .api(GreetingService.class);
 
     GreetingRequest request = new GreetingRequest("joe");
@@ -183,7 +184,7 @@ public class RemoteServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    GreetingService service = gateway.call()
+    GreetingService service = gateway.call().create()
         .api(GreetingService.class);
 
     GreetingRequest request = new GreetingRequest("joe");
@@ -409,7 +410,7 @@ public class RemoteServiceTest extends BaseTest {
         .startAwait();
 
     // Get a proxy to the service api.
-    CoarseGrainedService service = gateway.call().api(CoarseGrainedService.class);
+    CoarseGrainedService service = gateway.call().create().api(CoarseGrainedService.class);
 
     Publisher<String> future = service.callGreeting("joe");
 
@@ -435,7 +436,7 @@ public class RemoteServiceTest extends BaseTest {
         .startAwait();
 
     // Get a proxy to the service api.
-    CoarseGrainedService service = gateway.call().api(CoarseGrainedService.class);
+    CoarseGrainedService service = gateway.call().create().api(CoarseGrainedService.class);
     Publisher<String> future = service.callGreeting("joe");
     assertTrue(" hello to: joe".equals(Mono.from(future).block(Duration.ofSeconds(1))));
   }
@@ -461,7 +462,7 @@ public class RemoteServiceTest extends BaseTest {
         .startAwait();
 
     // Get a proxy to the service api.
-    CoarseGrainedService service = gateway.call().api(CoarseGrainedService.class);
+    CoarseGrainedService service = gateway.call().create().api(CoarseGrainedService.class);
     Mono.from(
         service.callGreetingTimeout("joe")).block();
 
@@ -488,7 +489,7 @@ public class RemoteServiceTest extends BaseTest {
         .startAwait();
 
     // Get a proxy to the service api.
-    CoarseGrainedService service = gateway.call().api(CoarseGrainedService.class);
+    CoarseGrainedService service = gateway.call().create().api(CoarseGrainedService.class);
 
     Mono.from(service.callGreetingWithDispatcher("joe"))
         .subscribe(success -> {
@@ -517,7 +518,7 @@ public class RemoteServiceTest extends BaseTest {
   }
 
   private GreetingService createProxy(Microservices micro) {
-    return micro.call().api(GreetingService.class); // create proxy for GreetingService API
+    return micro.call().create().api(GreetingService.class); // create proxy for GreetingService API
   }
 
   private Microservices createProvider(Microservices gateway) {

--- a/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
@@ -256,6 +256,32 @@ public class RemoteServiceTest extends BaseTest {
   }
 
   @Test
+  public void test_remote_greeting_no_params_fire_and_forget() {
+    // Create microservices cluster.
+    Microservices provider = Microservices.builder()
+        .discoveryPort(port.incrementAndGet())
+        .services(new GreetingServiceImpl())
+        .build()
+        .startAwait();
+
+    // Create microservices cluster.
+    Microservices consumer = Microservices.builder()
+        .discoveryPort(port.incrementAndGet())
+        .seeds(provider.cluster().address())
+        .build()
+        .startAwait();
+
+    // get a proxy to the service api.
+    GreetingService service = createProxy(consumer);
+
+    // call the service.
+    service.notifyGreeting();
+
+    provider.shutdown().block();
+    consumer.shutdown().block();
+  }
+
+  @Test
   public void test_remote_greeting_return_GreetingResponse() {
     // Create microservices cluster.
     Microservices provider = Microservices.builder()

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -64,7 +64,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        serviceCall.requestOne(GREETING_NO_PARAMS_REQUEST);
+        serviceCall.create().requestOne(GREETING_NO_PARAMS_REQUEST);
 
     ServiceMessage message = Mono.from(future).block(Duration.ofSeconds(TIMEOUT));
 
@@ -97,7 +97,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        serviceCall.requestOne(GREETING_NO_PARAMS_REQUEST, GreetingResponse.class);
+        serviceCall.create().requestOne(GREETING_NO_PARAMS_REQUEST, GreetingResponse.class);
 
     ServiceMessage message = Mono.from(future).block(timeout);
 
@@ -121,7 +121,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    gateway.call().oneWay(GREETING_VOID_REQ).block(Duration.ofSeconds(TIMEOUT));
+    gateway.call().create().oneWay(GREETING_VOID_REQ).block(Duration.ofSeconds(TIMEOUT));
 
     gateway.shutdown().block();
     node1.shutdown().block();
@@ -140,7 +140,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    StepVerifier.create(gateway.call().oneWay(GREETING_FAILING_VOID_REQ))
+    StepVerifier.create(gateway.call().create().oneWay(GREETING_FAILING_VOID_REQ))
         .expectErrorMessage(GREETING_FAILING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -161,7 +161,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    StepVerifier.create(gateway.call().oneWay(GREETING_THROWING_VOID_REQ))
+    StepVerifier.create(gateway.call().create().oneWay(GREETING_THROWING_VOID_REQ))
         .expectErrorMessage(GREETING_THROWING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -185,7 +185,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    Mono.from(gateway.call().requestOne(GREETING_FAIL_REQ, GreetingResponse.class)).block(timeout);
+    Mono.from(gateway.call().create().requestOne(GREETING_FAIL_REQ, GreetingResponse.class)).block(timeout);
 
     gateway.shutdown().block();
     node1.shutdown().block();
@@ -207,7 +207,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    Mono.from(gateway.call().requestOne(GREETING_ERROR_REQ, GreetingResponse.class)).block(timeout);
+    Mono.from(gateway.call().create().requestOne(GREETING_ERROR_REQ, GreetingResponse.class)).block(timeout);
 
     gateway.shutdown().block();
     node1.shutdown().block();
@@ -219,7 +219,7 @@ public class ServiceCallTest extends BaseTest {
     Microservices node = serviceProvider();
 
     // WHEN
-    node.call().oneWay(GREETING_VOID_REQ).block(Duration.ofSeconds(TIMEOUT));
+    node.call().create().oneWay(GREETING_VOID_REQ).block(Duration.ofSeconds(TIMEOUT));
 
     TimeUnit.SECONDS.sleep(2);
     node.shutdown().block();
@@ -230,7 +230,7 @@ public class ServiceCallTest extends BaseTest {
     // GIVEN
     Microservices node = serviceProvider();
 
-    StepVerifier.create(node.call().oneWay(GREETING_FAILING_VOID_REQ))
+    StepVerifier.create(node.call().create().oneWay(GREETING_FAILING_VOID_REQ))
         .expectErrorMessage(GREETING_FAILING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -243,7 +243,7 @@ public class ServiceCallTest extends BaseTest {
     // GIVEN
     Microservices node = serviceProvider();
 
-    StepVerifier.create(node.call().oneWay(GREETING_THROWING_VOID_REQ))
+    StepVerifier.create(node.call().create().oneWay(GREETING_THROWING_VOID_REQ))
         .expectErrorMessage(GREETING_THROWING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -260,7 +260,7 @@ public class ServiceCallTest extends BaseTest {
     Microservices node = serviceProvider();
 
     // call the service.
-    Mono.from(node.call().requestOne(GREETING_FAIL_REQ)).block(timeout);
+    Mono.from(node.call().create().requestOne(GREETING_FAIL_REQ)).block(timeout);
 
     node.shutdown().block();
   }
@@ -274,7 +274,7 @@ public class ServiceCallTest extends BaseTest {
     Microservices node = serviceProvider();
 
     // call the service.
-    Mono.from(node.call().requestOne(GREETING_ERROR_REQ)).block(timeout);
+    Mono.from(node.call().create().requestOne(GREETING_ERROR_REQ)).block(timeout);
 
     node.shutdown().block();
   }
@@ -291,7 +291,7 @@ public class ServiceCallTest extends BaseTest {
         .build()
         .startAwait();
 
-    Publisher<ServiceMessage> resultFuture = consumer.call().requestOne(GREETING_REQ, String.class);
+    Publisher<ServiceMessage> resultFuture = consumer.call().create().requestOne(GREETING_REQ, String.class);
 
     // Then
     ServiceMessage result = Mono.from(resultFuture).block(Duration.ofSeconds(TIMEOUT));
@@ -310,7 +310,7 @@ public class ServiceCallTest extends BaseTest {
 
     // When
     Publisher<ServiceMessage> resultFuture =
-        microservices.call().requestOne(GREETING_REQUEST_REQ);
+        microservices.call().create().requestOne(GREETING_REQUEST_REQ);
 
     // Then
     ServiceMessage result = Mono.from(resultFuture).block(Duration.ofSeconds(TIMEOUT));
@@ -333,7 +333,7 @@ public class ServiceCallTest extends BaseTest {
 
     // When
     Publisher<ServiceMessage> result =
-        consumer.call().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
+        consumer.call().create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
 
     // Then
     GreetingResponse greeting = Mono.from(result).block(Duration.ofSeconds(TIMEOUT)).data();
@@ -354,7 +354,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        service.requestOne(GREETING_REQUEST_TIMEOUT_REQ);
+        service.create().requestOne(GREETING_REQUEST_TIMEOUT_REQ);
 
     try {
       Mono.from(future).block(Duration.ofSeconds(1));
@@ -382,7 +382,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        service.requestOne(GREETING_REQUEST_TIMEOUT_REQ);
+        service.create().requestOne(GREETING_REQUEST_TIMEOUT_REQ);
     try {
       Mono.from(future).block(Duration.ofSeconds(1));
     } finally {
@@ -402,7 +402,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        service.requestOne(GREETING_REQUEST_REQ);
+        service.create().requestOne(GREETING_REQUEST_REQ);
 
 
     CountDownLatch timeLatch = new CountDownLatch(1);
@@ -434,7 +434,7 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     Publisher<ServiceMessage> future =
-        service.requestOne(GREETING_REQUEST_REQ);
+        service.create().requestOne(GREETING_REQUEST_REQ);
 
     Mono.from(future).doOnNext(result -> {
       // print the greeting.
@@ -472,9 +472,9 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     GreetingResponse result1 =
-        Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
     GreetingResponse result2 =
-        Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
 
     assertTrue(!result1.sender().equals(result2.sender()));
     provider2.shutdown().block();
@@ -509,7 +509,7 @@ public class ServiceCallTest extends BaseTest {
     // call the service.
     for (int i = 0; i < 1e3; i++) {
       GreetingResponse result =
-          Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
       assertEquals("2", result.sender());
     }
     provider2.shutdown().block();
@@ -544,9 +544,9 @@ public class ServiceCallTest extends BaseTest {
     // call the service.
     for (int i = 0; i < 1e2; i++) {
       GreetingResponse resultForFransin =
-          Mono.from(service.requestOne(GREETING_REQUEST_REQ2, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ2, GreetingResponse.class)).timeout(timeout).block().data();
       GreetingResponse resultForJoe =
-          Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
       assertEquals("1", resultForJoe.sender());
       assertEquals("2", resultForFransin.sender());
     }
@@ -567,7 +567,7 @@ public class ServiceCallTest extends BaseTest {
     CountDownLatch timeLatch = new CountDownLatch(1);
     try {
       // call the service.
-      Mono.from(service.requestOne(NOT_FOUND_REQ)).block(timeout);
+      Mono.from(service.create().requestOne(NOT_FOUND_REQ)).block(timeout);
       fail("Expected no-service-found exception");
     } catch (Exception ex) {
       assertTrue(ex.getMessage().equals("No reachable member with such service: " + NOT_FOUND_REQ.qualifier()));
@@ -612,7 +612,7 @@ public class ServiceCallTest extends BaseTest {
     int n = (int) 1e2;
     CountDownLatch timeLatch = new CountDownLatch(n);
     for (int i = 0; i < n; i++) {
-      Mono<ServiceMessage> response = service.requestOne(req, GreetingResponse.class);
+      Mono<ServiceMessage> response = service.create().requestOne(req, GreetingResponse.class);
       response.doOnNext(message -> {
         timeLatch.countDown();
         if (message.data().toString().contains("SERVICE_B_TALKING")) {
@@ -646,7 +646,7 @@ public class ServiceCallTest extends BaseTest {
         .build()
         .startAwait();
 
-    Publisher<ServiceMessage> result = gateway.call().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
+    Publisher<ServiceMessage> result = gateway.call().create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
 
     GreetingResponse greetings = Mono.from(result).block(Duration.ofSeconds(TIMEOUT)).data();
     System.out.println("greeting_request_completes_before_timeout : " + greetings.getResult());
@@ -666,7 +666,7 @@ public class ServiceCallTest extends BaseTest {
 
     Call service = gateway.call();
 
-    Publisher<ServiceMessage> result = service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
+    Publisher<ServiceMessage> result = service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class);
 
     GreetingResponse greetings = Mono.from(result).timeout(Duration.ofSeconds(TIMEOUT)).block().data();
     System.out.println("1. greeting_request_completes_before_timeout : " + greetings.getResult());

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -140,7 +140,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    StepVerifier.create(gateway.call().create().oneWay(GREETING_FAILING_VOID_REQ))
+    StepVerifier.create(gateway.call().create().requestOne(GREETING_FAILING_VOID_REQ, Void.class))
         .expectErrorMessage(GREETING_FAILING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -161,7 +161,7 @@ public class ServiceCallTest extends BaseTest {
         .startAwait();
 
     // When
-    StepVerifier.create(gateway.call().create().oneWay(GREETING_THROWING_VOID_REQ))
+    StepVerifier.create(gateway.call().create().requestOne(GREETING_THROWING_VOID_REQ, Void.class))
         .expectErrorMessage(GREETING_THROWING_VOID_REQ.data().toString())
         .verify(Duration.ofSeconds(TIMEOUT));
 
@@ -472,9 +472,11 @@ public class ServiceCallTest extends BaseTest {
 
     // call the service.
     GreetingResponse result1 =
-        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+            .data();
     GreetingResponse result2 =
-        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+        Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+            .data();
 
     assertTrue(!result1.sender().equals(result2.sender()));
     provider2.shutdown().block();
@@ -509,7 +511,8 @@ public class ServiceCallTest extends BaseTest {
     // call the service.
     for (int i = 0; i < 1e3; i++) {
       GreetingResponse result =
-          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+              .data();
       assertEquals("2", result.sender());
     }
     provider2.shutdown().block();
@@ -544,9 +547,11 @@ public class ServiceCallTest extends BaseTest {
     // call the service.
     for (int i = 0; i < 1e2; i++) {
       GreetingResponse resultForFransin =
-          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ2, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ2, GreetingResponse.class)).timeout(timeout).block()
+              .data();
       GreetingResponse resultForJoe =
-          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block().data();
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+              .data();
       assertEquals("1", resultForJoe.sender());
       assertEquals("2", resultForFransin.sender());
     }

--- a/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
@@ -1,6 +1,5 @@
 package io.scalecube.services.a.b.testing;
 
-import io.scalecube.services.Messages;
 import io.scalecube.services.ServiceReference;
 import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.registry.api.ServiceRegistry;
@@ -13,16 +12,15 @@ public class CanaryTestingRouter implements Router {
 
   @Override
   public Optional<ServiceReference> route(ServiceRegistry serviceRegistry, ServiceMessage request) {
-    String serviceName = Messages.qualifierOf(request).getNamespace();
     RandomCollection<ServiceReference> weightedRandom = new RandomCollection<>();
-    serviceRegistry.lookupService(serviceName)
+    serviceRegistry.lookupService(request.qualifier())
         .forEach(sr -> weightedRandom.add(Double.valueOf(sr.tags().get("Weight")), sr));
     return Optional.of(weightedRandom.next());
   }
 
   @Override
   public List<ServiceReference> routes(ServiceRegistry serviceRegistry, ServiceMessage request) {
-    return serviceRegistry.lookupService(Messages.qualifierOf(request).getNamespace());
+    return serviceRegistry.lookupService(request.qualifier());
   }
 
 }

--- a/services/src/test/java/io/scalecube/services/a/b/testing/ServiceTagsExample.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/ServiceTagsExample.java
@@ -2,7 +2,6 @@ package io.scalecube.services.a.b.testing;
 
 import io.scalecube.services.GreetingRequest;
 import io.scalecube.services.Microservices;
-import io.scalecube.services.routing.Routers;
 
 import reactor.core.publisher.Mono;
 

--- a/services/src/test/java/io/scalecube/services/a/b/testing/ServiceTagsExample.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/ServiceTagsExample.java
@@ -25,6 +25,7 @@ public class ServiceTagsExample {
 
     CanaryService service = gateway.call()
         .router(CanaryTestingRouter.class)
+        .create()
         .api(CanaryService.class);
 
     for (int i = 0; i < 10; i++) {

--- a/services/src/test/java/io/scalecube/services/streaming/StreamingServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/streaming/StreamingServiceTest.java
@@ -49,7 +49,7 @@ public class StreamingServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    QuoteService service = node.call().api(QuoteService.class);
+    QuoteService service = node.call().create().api(QuoteService.class);
 
     CountDownLatch latch = new CountDownLatch(3);
     Flux<String> obs = service.quotes();
@@ -77,7 +77,7 @@ public class StreamingServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    QuoteService service = gateway.call().api(QuoteService.class);
+    QuoteService service = gateway.call().create().api(QuoteService.class);
     CountDownLatch latch1 = new CountDownLatch(3);
     CountDownLatch latch2 = new CountDownLatch(3);
 
@@ -117,7 +117,7 @@ public class StreamingServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    QuoteService service = gateway.call().api(QuoteService.class);
+    QuoteService service = gateway.call().create().api(QuoteService.class);
     CountDownLatch latch1 = new CountDownLatch(streamBound);
 
     Disposable sub1 = service.snapshot(streamBound)
@@ -149,7 +149,7 @@ public class StreamingServiceTest extends BaseTest {
     Call service = gateway.call();
 
     CountDownLatch latch1 = new CountDownLatch(batchSize);
-    Disposable sub1 = Flux.from(service.requestMany(Messages.builder()
+    Disposable sub1 = Flux.from(service.create().requestMany(Messages.builder()
         .request(QuoteService.NAME, "snapshot")
         .data(batchSize)
         .build()))
@@ -177,7 +177,7 @@ public class StreamingServiceTest extends BaseTest {
         .build()
         .startAwait();
 
-    QuoteService service = gateway.call().api(QuoteService.class);
+    QuoteService service = gateway.call().create().api(QuoteService.class);
 
     assertEquals("1", service.justOne().block(Duration.ofSeconds(2)));
 
@@ -203,7 +203,7 @@ public class StreamingServiceTest extends BaseTest {
     final CountDownLatch latch1 = new CountDownLatch(batchSize);
     ServiceMessage justOne = Messages.builder().request(QuoteService.NAME, "justOne").build();
 
-    Flux.from(service.requestOne(justOne)).subscribe(onNext -> latch1.countDown());
+    Flux.from(service.create().requestOne(justOne)).subscribe(onNext -> latch1.countDown());
 
     latch1.await(2, TimeUnit.SECONDS);
     assertTrue(latch1.getCount() == 0);
@@ -230,7 +230,7 @@ public class StreamingServiceTest extends BaseTest {
     ServiceMessage scheduled = Messages.builder().request(QuoteService.NAME, "scheduled")
         .data(1000).build();
 
-    sub1.set(Flux.from(service.requestMany(scheduled)).subscribe(onNext -> {
+    sub1.set(Flux.from(service.create().requestMany(scheduled)).subscribe(onNext -> {
       sub1.get().isDisposed();
       latch1.countDown();
 
@@ -262,7 +262,7 @@ public class StreamingServiceTest extends BaseTest {
 
     ServiceMessage scheduled = Messages.builder().request(QuoteService.NAME, "unknonwn").build();
     try {
-      service.requestMany(scheduled).blockFirst(Duration.ofSeconds(3));
+      service.create().requestMany(scheduled).blockFirst(Duration.ofSeconds(3));
     } catch (Exception ex) {
       if (ex.getMessage().contains("No reachable member with such service")) {
         latch1.countDown();
@@ -297,7 +297,7 @@ public class StreamingServiceTest extends BaseTest {
     AtomicReference<Disposable> sub1 = new AtomicReference<>(null);
     ServiceMessage justOne = Messages.builder().request(QuoteService.NAME, "justOne").build();
 
-    sub1.set(Flux.from(service.requestMany(justOne)).subscribe(System.out::println));
+    sub1.set(Flux.from(service.create().requestMany(justOne)).subscribe(System.out::println));
 
     gateway.cluster().listenMembership()
         .filter(MembershipEvent::isRemoved)


### PR DESCRIPTION
* change behavior of Mono<Void> to be request one and not oneWay since empty response is still one response - only native void function will be one way

``` java
void notifyOnly(String s) ; // FIRE_AND_FORGET
Mono<Void> ackMe(String s); // REQUEST_RESPONSE
```
* change discovery to use qualifier and not break using action and namespace.
* change service call builder and introduce .create() to better care of mutibility

```java
ServiceCall.call().router(...).create();
```
* Add CommunicationType to service reference so client will know how to invoke the service endpoint
* Add invoke method that uses CommuicationType when invokeing a service endpoint.
