### PR TITLE
Introduce Gson codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>services-codec-jackson</module>
         <module>services</module>
         <module>benchmarks</module>
+        <module>scalecube-services-gson</module>
     </modules>
 
   <dependencyManagement>

--- a/scalecube-services-gson/pom.xml
+++ b/scalecube-services-gson/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.scalecube</groupId>
+		<artifactId>scalecube-services-parent</artifactId>
+		<version>2.0.18-SNAPSHOT</version>
+	</parent>
+	<artifactId>scalecube-services-gson</artifactId>
+	<name>Scalecube/services-codec-gson</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>scalecube-services-codec</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.5</version>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/scalecube-services-gson/src/main/java/io/scalecube/services/codec/gson/GsonCodec.java
+++ b/scalecube-services-gson/src/main/java/io/scalecube/services/codec/gson/GsonCodec.java
@@ -1,0 +1,73 @@
+package io.scalecube.services.codec.gson;
+
+import io.scalecube.services.codec.DataCodec;
+import io.scalecube.services.codec.HeadersCodec;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import org.apache.logging.log4j.core.util.IOUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class GsonCodec implements DataCodec, HeadersCodec {
+
+  private Gson gson;
+
+  @Override
+  public String contentType() {
+    return "application/json";
+  }
+
+  public GsonCodec() {
+    this(initMapper());
+  }
+
+  private static Gson initMapper() {
+    return new Gson();
+  }
+
+  public GsonCodec(Gson mapper) {
+    this.gson = mapper;
+  }
+
+
+  @Override
+  public void encode(OutputStream out, Map<String, String> headers) throws IOException {
+    try (JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"))) {
+      gson.toJson(headers, Map.class, writer);
+    }
+  }
+
+  @Override
+  public Map<String, String> decode(InputStream stream) throws IOException {
+    try (JsonReader reader = new JsonReader(new InputStreamReader(stream, "UTF-8"))) {
+      return stream.available() == 0 ? Collections.emptyMap() : gson.fromJson(reader, Map.class);
+    }
+  }
+
+  @Override
+  public void encode(OutputStream out, Object value) throws IOException {
+    try (JsonWriter writer = new JsonWriter(new OutputStreamWriter(out, "UTF-8"))) {
+      gson.toJson(value, value.getClass(), writer);
+    }
+  }
+
+  @Override
+  public Object decode(InputStream stream, Class<?> type) throws IOException {
+    Objects.requireNonNull(type, "ServiceMessageDataCodecImpl.readFrom requires type is not null");
+    try (JsonReader reader = new JsonReader(new InputStreamReader(stream, "UTF-8"))) {
+      return gson.fromJson(reader, type);
+    }
+  }
+}

--- a/scalecube-services-gson/src/main/java/io/scalecube/services/codec/gson/GsonCodec.java
+++ b/scalecube-services-gson/src/main/java/io/scalecube/services/codec/gson/GsonCodec.java
@@ -7,9 +7,6 @@ import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
-import org.apache.logging.log4j.core.util.IOUtils;
-
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -18,7 +15,6 @@ import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public final class GsonCodec implements DataCodec, HeadersCodec {
 

--- a/scalecube-services-gson/src/main/resources/META-INF/services/io.scalecube.services.codec.DataCodec
+++ b/scalecube-services-gson/src/main/resources/META-INF/services/io.scalecube.services.codec.DataCodec
@@ -1,0 +1,1 @@
+io.scalecube.services.codec.gson.GsonCodec

--- a/scalecube-services-gson/src/main/resources/META-INF/services/io.scalecube.services.codec.HeadersCodec
+++ b/scalecube-services-gson/src/main/resources/META-INF/services/io.scalecube.services.codec.HeadersCodec
@@ -1,0 +1,1 @@
+io.scalecube.services.codec.gson.GsonCodec

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageCodec.java
@@ -1,10 +1,7 @@
 package io.scalecube.services.codec;
 
-import java.nio.charset.Charset;
-import java.util.function.BiFunction;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.exceptions.BadRequestException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -12,8 +9,12 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.exceptions.BadRequestException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.util.function.BiFunction;
 
 public final class ServiceMessageCodec {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceMessageCodec.class);

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageCodec.java
@@ -1,7 +1,10 @@
 package io.scalecube.services.codec;
 
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.exceptions.BadRequestException;
+import java.nio.charset.Charset;
+import java.util.function.BiFunction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -9,19 +12,13 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.util.ReferenceCountUtil;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.nio.charset.Charset;
-import java.util.Optional;
-import java.util.function.BiFunction;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.exceptions.BadRequestException;
 
 public final class ServiceMessageCodec {
-
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceMessageCodec.class);
-
   private static final String DEFAULT_DATA_FORMAT = "application/json";
+  private static final DataCodec dataCodec = DataCodec.getInstance(DEFAULT_DATA_FORMAT);
 
   private final HeadersCodec headersCodec;
 
@@ -38,8 +35,6 @@ public final class ServiceMessageCodec {
     } else if (message.hasData()) {
       dataBuffer = ByteBufAllocator.DEFAULT.buffer();
       try {
-        String contentType = Optional.ofNullable(message.dataFormat()).orElse(DEFAULT_DATA_FORMAT);
-        DataCodec dataCodec = DataCodec.getInstance(contentType);
         dataCodec.encode(new ByteBufOutputStream(dataBuffer), message.data());
       } catch (Throwable ex) {
         ReferenceCountUtil.release(dataBuffer);

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
@@ -1,21 +1,19 @@
 package io.scalecube.services.codec;
 
-import io.scalecube.services.api.ErrorData;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.exceptions.BadRequestException;
-import io.scalecube.services.exceptions.ExceptionProcessor;
+import java.nio.charset.Charset;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.util.ReferenceCountUtil;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.nio.charset.Charset;
-import java.util.Optional;
+import io.scalecube.services.api.ErrorData;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.exceptions.BadRequestException;
+import io.scalecube.services.exceptions.ExceptionProcessor;
 
 public final class ServiceMessageDataCodec {
 
@@ -23,14 +21,14 @@ public final class ServiceMessageDataCodec {
 
   private static final String DEFAULT_DATA_FORMAT = "application/json";
 
+  public static final DataCodec dataCodec = DataCodec.getInstance(DEFAULT_DATA_FORMAT);
+
   public ServiceMessage encode(ServiceMessage message) {
     if (message.hasData(ByteBuf.class)) {
       return message;
     } else if (message.hasData()) {
       ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer();
       try {
-        String contentType = Optional.ofNullable(message.dataFormat()).orElse(DEFAULT_DATA_FORMAT);
-        DataCodec dataCodec = DataCodec.getInstance(contentType);
         dataCodec.encode(new ByteBufOutputStream(buffer), message.data());
         return ServiceMessage.from(message).data(buffer).build();
       } catch (Throwable ex) {
@@ -51,8 +49,6 @@ public final class ServiceMessageDataCodec {
     Class<?> targetType = ExceptionProcessor.isError(message) ? ErrorData.class : type;
 
     try (ByteBufInputStream inputStream = new ByteBufInputStream(((ByteBuf) message.data()).slice())) {
-      String contentType = Optional.ofNullable(message.dataFormat()).orElse(DEFAULT_DATA_FORMAT);
-      DataCodec dataCodec = DataCodec.getInstance(contentType);
       data = dataCodec.decode(inputStream, targetType);
     } catch (Throwable ex) {
       LOGGER.error("Failed to decode data on: {}, data buffer: {}, cause: {}",

--- a/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
+++ b/services-codec/src/main/java/io/scalecube/services/codec/ServiceMessageDataCodec.java
@@ -1,19 +1,20 @@
 package io.scalecube.services.codec;
 
-import java.nio.charset.Charset;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.scalecube.services.api.ErrorData;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.exceptions.BadRequestException;
+import io.scalecube.services.exceptions.ExceptionProcessor;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.util.ReferenceCountUtil;
-import io.scalecube.services.api.ErrorData;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.exceptions.BadRequestException;
-import io.scalecube.services.exceptions.ExceptionProcessor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
 
 public final class ServiceMessageDataCodec {
 

--- a/services/src/main/java/io/scalecube/services/MethodInfo.java
+++ b/services/src/main/java/io/scalecube/services/MethodInfo.java
@@ -1,0 +1,28 @@
+package io.scalecube.services;
+
+public class MethodInfo {
+
+  private final Class<?> parameterizedReturnType;
+  private final CommunicationMode communicationMode;
+  private final boolean isRequestTypeServiceMessage;
+
+  public MethodInfo(Class<?> parameterizedReturnType,
+      CommunicationMode communicationMode,
+      boolean isRequestTypeServiceMessage) {
+    this.parameterizedReturnType = parameterizedReturnType;
+    this.communicationMode = communicationMode;
+    this.isRequestTypeServiceMessage = isRequestTypeServiceMessage;
+  }
+
+  public Class<?> parameterizedReturnType() {
+    return parameterizedReturnType;
+  }
+
+  public CommunicationMode communicationMode() {
+    return communicationMode;
+  }
+
+  public boolean isRequestTypeServiceMessage() {
+    return isRequestTypeServiceMessage;
+  }
+}

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -236,11 +236,11 @@ public class Reflect {
    * 
    * @return the parameterized Type of a given object or Object class if unknown.
    */
-  public static Class<?> parameterizedRequestType(Method method) {
+  public static Type parameterizedRequestType(Method method) {
     if (method != null && method.getGenericParameterTypes().length > 0) {
       Type type = method.getGenericParameterTypes()[0];
       if (type instanceof ParameterizedType) {
-        return (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0];
+        return ((ParameterizedType) type).getActualTypeArguments()[0];
       }
     }
 

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -6,23 +6,6 @@ import static io.scalecube.services.CommunicationMode.REQUEST_RESPONSE;
 import static io.scalecube.services.CommunicationMode.REQUEST_STREAM;
 import static java.util.Objects.requireNonNull;
 
-import io.scalecube.services.annotations.Inject;
-import io.scalecube.services.annotations.Null;
-import io.scalecube.services.annotations.RequestType;
-import io.scalecube.services.annotations.Service;
-import io.scalecube.services.annotations.ServiceMethod;
-import io.scalecube.services.api.Qualifier;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.routing.RoundRobinServiceRouter;
-import io.scalecube.services.routing.Router;
-import io.scalecube.services.routing.Routers;
-
-import com.google.common.base.Strings;
-
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -38,6 +21,22 @@ import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+
+import io.scalecube.services.annotations.Inject;
+import io.scalecube.services.annotations.Null;
+import io.scalecube.services.annotations.RequestType;
+import io.scalecube.services.annotations.Service;
+import io.scalecube.services.annotations.ServiceMethod;
+import io.scalecube.services.api.Qualifier;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.routing.RoundRobinServiceRouter;
+import io.scalecube.services.routing.Router;
+import io.scalecube.services.routing.Routers;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -224,16 +223,21 @@ public class Reflect {
     return Object.class;
   }
 
+  public static Map<Method, Class<?>> parameterizedReturnTypes(Class<?> serviceInterface) {
+    return Collections.unmodifiableMap(Reflect.serviceMethods(serviceInterface).values().stream()
+        .collect(Collectors.toMap(m -> m, Reflect::parameterizedReturnType)));
+  }
+
   /**
    * Util function that returns the parameterized of the request Type of a given object.
    * 
    * @return the parameterized Type of a given object or Object class if unknown.
    */
-  public static Type parameterizedRequestType(Method method) {
+  public static Class<?> parameterizedRequestType(Method method) {
     if (method != null && method.getGenericParameterTypes().length > 0) {
       Type type = method.getGenericParameterTypes()[0];
       if (type instanceof ParameterizedType) {
-        return ((ParameterizedType) type).getActualTypeArguments()[0];
+        return (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0];
       }
     }
 
@@ -378,4 +382,6 @@ public class Reflect {
       return Flux.error(ex);
     }
   }
+
+
 }

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -223,9 +223,12 @@ public class Reflect {
     return Object.class;
   }
 
-  public static Map<Method, Class<?>> parameterizedReturnTypes(Class<?> serviceInterface) {
+  public static Map<Method, MethodInfo> methodsInfo(Class<?> serviceInterface) {
     return Collections.unmodifiableMap(Reflect.serviceMethods(serviceInterface).values().stream()
-        .collect(Collectors.toMap(m -> m, Reflect::parameterizedReturnType)));
+        .collect(Collectors.toMap(m -> m, m-> 
+          new MethodInfo(parameterizedReturnType(m),
+              communicationMode(m),
+              isRequestTypeServiceMessage(m)))));
   }
 
   /**

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -6,6 +6,23 @@ import static io.scalecube.services.CommunicationMode.REQUEST_RESPONSE;
 import static io.scalecube.services.CommunicationMode.REQUEST_STREAM;
 import static java.util.Objects.requireNonNull;
 
+import io.scalecube.services.annotations.Inject;
+import io.scalecube.services.annotations.Null;
+import io.scalecube.services.annotations.RequestType;
+import io.scalecube.services.annotations.Service;
+import io.scalecube.services.annotations.ServiceMethod;
+import io.scalecube.services.api.Qualifier;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.routing.RoundRobinServiceRouter;
+import io.scalecube.services.routing.Router;
+import io.scalecube.services.routing.Routers;
+
+import com.google.common.base.Strings;
+
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -21,22 +38,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Strings;
-
-import io.scalecube.services.annotations.Inject;
-import io.scalecube.services.annotations.Null;
-import io.scalecube.services.annotations.RequestType;
-import io.scalecube.services.annotations.Service;
-import io.scalecube.services.annotations.ServiceMethod;
-import io.scalecube.services.api.Qualifier;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.routing.RoundRobinServiceRouter;
-import io.scalecube.services.routing.Router;
-import io.scalecube.services.routing.Routers;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -11,7 +11,6 @@ import com.google.common.reflect.Reflection;
 
 import io.scalecube.services.api.NullData;
 import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.api.ServiceMessageHandler;
 import io.scalecube.services.codec.ServiceMessageDataCodec;
 import io.scalecube.services.exceptions.ExceptionProcessor;
 import io.scalecube.services.exceptions.ServiceUnavailableException;
@@ -157,14 +156,14 @@ public class ServiceCall {
         .flatMap(pair -> {
           ServiceMessage request = pair.head();
           String qualifier = request.qualifier();
-          
+
           Flux<ServiceMessage> requestPublisher = Flux.from(pair.tail()).startWith(request);
 
-          if (serviceHandlers.contains(qualifier)) {
+          if (serviceHandlers.contains(qualifier)) { // local service.
             return serviceHandlers.get(qualifier)
                 .invoke(requestPublisher)
                 .onErrorMap(ExceptionProcessor::mapException);
-          } else {
+          } else { // remote service.
             return transport.create(addressLookup(request))
                 .requestBidirectional(requestPublisher)
                 .map(message -> dataCodec.decode(message, responseType));

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -1,5 +1,14 @@
 package io.scalecube.services;
 
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.Reflection;
+
 import io.scalecube.services.api.NullData;
 import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.api.ServiceMessageHandler;
@@ -14,13 +23,6 @@ import io.scalecube.services.transport.HeadAndTail;
 import io.scalecube.services.transport.LocalServiceHandlers;
 import io.scalecube.services.transport.client.api.ClientTransport;
 import io.scalecube.transport.Address;
-
-import com.google.common.reflect.Reflection;
-
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -187,7 +189,8 @@ public class ServiceCall {
   public <T> T api(Class<T> serviceInterface) {
 
     final ServiceCall serviceCall = this;
-
+    final Map<Method, Class<?>> genericReturnTypes = Reflect.parameterizedReturnTypes(serviceInterface);
+    
     return Reflection.newProxy(serviceInterface, (proxy, method, args) -> {
 
       Object check = objectToStringEqualsHashCode(method.getName(), serviceInterface, args);
@@ -196,7 +199,7 @@ public class ServiceCall {
       }
 
       Metrics.mark(serviceInterface, metrics, method, "request");
-      Class<?> parameterizedReturnType = Reflect.parameterizedReturnType(method);
+      Class<?> parameterizedReturnType = genericReturnTypes.get(method);
       boolean isRequestTypeServiceMessage = Reflect.isRequestTypeServiceMessage(method);
       CommunicationMode mode = Reflect.communicationMode(method);
 

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -1,14 +1,5 @@
 package io.scalecube.services;
 
-import java.lang.reflect.Method;
-import java.util.Map;
-
-import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.reflect.Reflection;
-
 import io.scalecube.services.api.NullData;
 import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.codec.ServiceMessageDataCodec;
@@ -22,6 +13,16 @@ import io.scalecube.services.transport.HeadAndTail;
 import io.scalecube.services.transport.LocalServiceHandlers;
 import io.scalecube.services.transport.client.api.ClientTransport;
 import io.scalecube.transport.Address;
+
+import com.google.common.reflect.Reflection;
+
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 

--- a/services/src/main/java/io/scalecube/services/routing/Routers.java
+++ b/services/src/main/java/io/scalecube/services/routing/Routers.java
@@ -1,25 +1,20 @@
 package io.scalecube.services.routing;
 
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.scalecube.services.ServiceReference;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.transport.Address;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 public class Routers {
   private static final Logger LOGGER = LoggerFactory.getLogger(Routers.class);
 
   private static final ConcurrentHashMap<Class<? extends Router>, Router> routers = new ConcurrentHashMap<>();
 
-  private Routers() {
-  }
+  private Routers() {}
 
   /**
-   * get router instance by a given router class.
-   * The class should have a default constructor. otherwise no router can be created
+   * get router instance by a given router class. The class should have a default constructor. otherwise no router can
+   * be created
    * 
    * @param routing the type of the Router.
    * @return instance of the Router.

--- a/services/src/main/java/io/scalecube/services/routing/Routers.java
+++ b/services/src/main/java/io/scalecube/services/routing/Routers.java
@@ -1,9 +1,9 @@
 package io.scalecube.services.routing;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Routers {
   private static final Logger LOGGER = LoggerFactory.getLogger(Routers.class);

--- a/services/src/main/java/io/scalecube/services/routing/Routers.java
+++ b/services/src/main/java/io/scalecube/services/routing/Routers.java
@@ -3,6 +3,10 @@ package io.scalecube.services.routing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.scalecube.services.ServiceReference;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.transport.Address;
+
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Routers {

--- a/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/RemoteServiceTest.java
@@ -4,19 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.reactivestreams.Publisher;
-
 import io.scalecube.cluster.ClusterConfig;
 import io.scalecube.cluster.ClusterConfig.Builder;
 import io.scalecube.services.a.b.testing.CanaryService;
@@ -25,6 +12,20 @@ import io.scalecube.services.a.b.testing.GreetingServiceImplA;
 import io.scalecube.services.a.b.testing.GreetingServiceImplB;
 import io.scalecube.services.exceptions.InternalServiceException;
 import io.scalecube.services.routing.Routers;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.reactivestreams.Publisher;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 

--- a/services/src/test/java/io/scalecube/services/RoutersTest.java
+++ b/services/src/test/java/io/scalecube/services/RoutersTest.java
@@ -186,7 +186,7 @@ public class RoutersTest extends BaseTest {
 
     System.out.println("Service B was called: " + serviceBCount.get() + " times.");
 
-    assertEquals(0.6d, serviceBCount.doubleValue() / n, 0.2d);
+    assertEquals(0.6d, serviceBCount.doubleValue() / n, 0.25d);
 
     services1.shutdown().block();
     services2.shutdown().block();

--- a/services/src/test/java/io/scalecube/services/RoutersTest.java
+++ b/services/src/test/java/io/scalecube/services/RoutersTest.java
@@ -5,11 +5,6 @@ import static io.scalecube.services.TestRequests.GREETING_REQUEST_REQ2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-
 import io.scalecube.services.ServiceCall.Call;
 import io.scalecube.services.a.b.testing.CanaryService;
 import io.scalecube.services.a.b.testing.CanaryTestingRouter;
@@ -19,11 +14,17 @@ import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.routing.RandomServiceRouter;
 import io.scalecube.services.routing.Router;
 import io.scalecube.services.routing.Routers;
-import reactor.core.publisher.Mono;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
 
 public class RoutersTest extends BaseTest {
   public static final int TIMEOUT = 3;

--- a/services/src/test/java/io/scalecube/services/RoutersTest.java
+++ b/services/src/test/java/io/scalecube/services/RoutersTest.java
@@ -1,15 +1,46 @@
 package io.scalecube.services;
 
+import static io.scalecube.services.TestRequests.GREETING_REQUEST_REQ;
+import static io.scalecube.services.TestRequests.GREETING_REQUEST_REQ2;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import io.scalecube.services.ServiceCall.Call;
+import io.scalecube.services.a.b.testing.CanaryService;
+import io.scalecube.services.a.b.testing.CanaryTestingRouter;
+import io.scalecube.services.a.b.testing.GreetingServiceImplA;
+import io.scalecube.services.a.b.testing.GreetingServiceImplB;
+import io.scalecube.services.api.ServiceMessage;
 import io.scalecube.services.routing.RandomServiceRouter;
 import io.scalecube.services.routing.Router;
 import io.scalecube.services.routing.Routers;
+import reactor.core.publisher.Mono;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class RoutersTest extends BaseTest {
+  public static final int TIMEOUT = 3;
+  private Duration timeout = Duration.ofSeconds(TIMEOUT);
 
+  private Microservices gateway;
+  
+  @Before
+  public void setup() {
+    this.gateway =  Microservices.builder().build().startAwait();
+  }
+  
+  @After
+  public void tearDown() {
+    gateway.shutdown().block();
+  }
+  
   @Test
   public void test_router_factory() {
     Router router = Routers.getRouter(RandomServiceRouter.class);
@@ -21,5 +52,144 @@ public class RoutersTest extends BaseTest {
 
   }
 
+  
+
+  @Test
+  public void test_round_robin_selection_logic() {
+    // Create microservices instance cluster.
+    Microservices provider1 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .services(new GreetingServiceImpl(1))
+        .build()
+        .startAwait();
+
+    // Create microservices instance cluster.
+    Microservices provider2 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .services(new GreetingServiceImpl(2))
+        .build()
+        .startAwait();
+
+    ServiceCall service = gateway.call().create();
+
+    // call the service.
+    GreetingResponse result1 =
+        Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+            .data();
+    GreetingResponse result2 =
+        Mono.from(service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+            .data();
+
+    assertTrue(!result1.sender().equals(result2.sender()));
+    provider2.shutdown().block();
+    provider1.shutdown().block();
+  }
+
+  @Test
+  public void test_tag_selection_logic() {
+
+    // Create microservices instance cluster.
+    Microservices provider1 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImpl(1)).tag("SENDER", "1").register()
+        .build()
+        .startAwait();
+
+    // Create microservices instance cluster.
+    Microservices provider2 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImpl(2)).tag("SENDER", "2").register()
+        .build()
+        .startAwait();
+
+    Call service = gateway.call().router((reg, msg) -> reg.listServiceReferences().stream().filter(ref -> "2".equals(
+        ref.tags().get("SENDER"))).collect(Collectors.toList()));
+
+    // call the service.
+    for (int i = 0; i < 1e3; i++) {
+      GreetingResponse result =
+          Mono.from(service.create().requestOne(GREETING_REQUEST_REQ, GreetingResponse.class)).timeout(timeout).block()
+              .data();
+      assertEquals("2", result.sender());
+    }
+    provider2.shutdown().block();
+    provider1.shutdown().block();
+  }
+
+  @Test
+  public void test_tag_request_selection_logic() {
+    // Create microservices instance cluster.
+    Microservices provider1 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImpl(1)).tag("ONLYFOR", "joe").register()
+        .build()
+        .startAwait();
+
+    // Create microservices instance cluster.
+    Microservices provider2 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImpl(2)).tag("ONLYFOR", "fransin").register()
+        .build()
+        .startAwait();
+
+    ServiceCall service = gateway.call().router(
+        (reg, msg) -> reg.listServiceReferences().stream().filter(ref -> ((GreetingRequest) msg.data()).getName()
+            .equals(ref.tags().get("ONLYFOR"))).collect(Collectors.toList()))
+        .create();
+
+    // call the service.
+    for (int i = 0; i < 1e2; i++) {
+      GreetingResponse resultForFransin =
+          service.requestOne(GREETING_REQUEST_REQ2, GreetingResponse.class).block(timeout).data();
+      GreetingResponse resultForJoe =
+          service.requestOne(GREETING_REQUEST_REQ, GreetingResponse.class).block(timeout).data();
+      assertEquals("1", resultForJoe.sender());
+      assertEquals("2", resultForFransin.sender());
+    }
+    provider2.shutdown().block();
+    provider1.shutdown().block();
+  }
+
+  @Test
+  public void test_service_tags() throws Exception {
+    Microservices services1 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImplA()).tag("Weight", "0.3").register()
+        .build()
+        .startAwait();
+
+    Microservices services2 = Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .service(new GreetingServiceImplB()).tag("Weight", "0.7").register()
+        .build()
+        .startAwait();
+
+    System.out.println(gateway.cluster().members());
+
+    TimeUnit.SECONDS.sleep(3);
+    ServiceCall service = gateway.call().router(CanaryTestingRouter.class).create();
+
+    ServiceMessage req = ServiceMessage.builder()
+        .qualifier(Reflect.serviceName(CanaryService.class), "greeting")
+        .data(new GreetingRequest("joe"))
+        .build();
+
+    AtomicInteger serviceBCount = new AtomicInteger(0);
+
+    int n = (int) 1e2;
+    for (int i = 0; i < n; i++) {
+      ServiceMessage message = service.requestOne(req, GreetingResponse.class).block(timeout);
+      if (message.data().toString().contains("SERVICE_B_TALKING")) {
+        serviceBCount.incrementAndGet();
+      }
+    }
+
+    System.out.println("Service B was called: " + serviceBCount.get() + " times.");
+
+    assertEquals(0.6d, serviceBCount.doubleValue() / n, 0.2d);
+
+    services1.shutdown().block();
+    services2.shutdown().block();
+  }
 
 }

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -123,6 +123,7 @@ public class ServiceCallTest extends BaseTest {
 
   @Test
   public void test_remote_failing_void_greeting() {
+
     // Given
     Microservices node1 = Microservices.builder()
         .seeds(gateway.cluster().address())

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -18,9 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -43,7 +41,6 @@ public class ServiceCallTest extends BaseTest {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-  private static AtomicInteger port = new AtomicInteger(4000);
 
   private Microservices gateway;
   
@@ -77,7 +74,6 @@ public class ServiceCallTest extends BaseTest {
 
   private Microservices serviceProvider() {
     return Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .services(new GreetingServiceImpl())
         .build()
         .startAwait();
@@ -90,7 +86,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Create microservices cluster.
     Microservices consumer = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(provider.cluster().address())
         .build()
         .startAwait();
@@ -115,7 +110,6 @@ public class ServiceCallTest extends BaseTest {
     // Given
 
     Microservices node1 = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -131,7 +125,6 @@ public class ServiceCallTest extends BaseTest {
   public void test_remote_failing_void_greeting() {
     // Given
     Microservices node1 = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -149,7 +142,6 @@ public class ServiceCallTest extends BaseTest {
   public void test_remote_throwing_void_greeting() {
     // Given
     Microservices node1 = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -170,7 +162,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Given
     Microservices node1 = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -189,7 +180,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Given
     Microservices node1 = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -274,7 +264,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Create microservices cluster.
     Microservices consumer = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(provider.cluster().address())
         .build()
         .startAwait();
@@ -314,7 +303,6 @@ public class ServiceCallTest extends BaseTest {
     // Given
     Microservices provider = serviceProvider();
     Microservices consumer = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(provider.cluster().address())
         .build()
         .startAwait();
@@ -361,7 +349,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Create microservices cluster.
     Microservices consumer = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(provider.cluster().address())
         .build()
         .startAwait();
@@ -407,7 +394,6 @@ public class ServiceCallTest extends BaseTest {
 
     // Create microservices cluster.
     Microservices consumer = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(provider.cluster().address())
         .build()
         .startAwait();
@@ -435,7 +421,6 @@ public class ServiceCallTest extends BaseTest {
     // Create microservices instance cluster.
     Microservices provider1 = Microservices.builder()
         .seeds(gateway.cluster().address())
-        .discoveryPort(port.incrementAndGet())
         .services(new GreetingServiceImpl(1))
         .build()
         .startAwait();
@@ -443,7 +428,6 @@ public class ServiceCallTest extends BaseTest {
     // Create microservices instance cluster.
     Microservices provider2 = Microservices.builder()
         .seeds(gateway.cluster().address())
-        .discoveryPort(port.incrementAndGet())
         .services(new GreetingServiceImpl(2))
         .build()
         .startAwait();
@@ -488,7 +472,6 @@ public class ServiceCallTest extends BaseTest {
   public void test_dispatcher_remote_greeting_request_completes_before_timeout() {
     // Create microservices instance.
     Microservices node = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .seeds(gateway.cluster().address())
         .services(new GreetingServiceImpl())
         .build()
@@ -506,7 +489,6 @@ public class ServiceCallTest extends BaseTest {
   @Test
   public void test_dispatcher_local_greeting_request_completes_before_timeout() {
     Microservices gateway = Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .services(new GreetingServiceImpl())
         .build()
         .startAwait();
@@ -525,19 +507,13 @@ public class ServiceCallTest extends BaseTest {
   private Microservices provider(Microservices gateway) {
     return Microservices.builder()
         .seeds(gateway.cluster().address())
-        .discoveryPort(port.incrementAndGet())
         .build()
         .startAwait();
   }
 
   private Microservices gateway() {
     return Microservices.builder()
-        .discoveryPort(port.incrementAndGet())
         .build()
         .startAwait();
-  }
-
-  private boolean await(CountDownLatch timeLatch, long timeout, TimeUnit timeUnit) throws Exception {
-    return timeLatch.await(timeout, timeUnit);
   }
 }

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -17,8 +17,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
+import io.scalecube.services.ServiceCall.Call;
+import io.scalecube.services.api.ServiceMessage;
+import io.scalecube.services.exceptions.ServiceException;
+import io.scalecube.services.routing.RoundRobinServiceRouter;
 
 import org.junit.After;
 import org.junit.Before;
@@ -27,10 +29,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.reactivestreams.Publisher;
 
-import io.scalecube.services.ServiceCall.Call;
-import io.scalecube.services.api.ServiceMessage;
-import io.scalecube.services.exceptions.ServiceException;
-import io.scalecube.services.routing.RoundRobinServiceRouter;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 


### PR DESCRIPTION
Add Gson message codec to benchmark vs Jackson

according to this benchmark done by takipi (thank you takipi)

https://blog.takipi.com/the-ultimate-json-library-json-simple-vs-gson-vs-jackson-vs-json/

![image](https://user-images.githubusercontent.com/1706296/40623293-ccb7860e-62ae-11e8-9893-ff0cc21f5e73.png)

Gson performs better on small object.

running under profile it seem to be correct but over all performance not getting better.


```java
package io.scalecube.services.benchmarks;

import io.scalecube.services.Microservices;

import java.util.concurrent.CompletableFuture;
import java.util.concurrent.ExecutionException;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;
import java.util.concurrent.atomic.AtomicInteger;

import reactor.core.publisher.Flux;

public class ServicesBenchmark {

  public static AtomicInteger total = new AtomicInteger(0);

  public static void main(String[] args) throws InterruptedException, ExecutionException {
    Microservices gateway = Microservices.builder().build().startAwait();

    Microservices node = Microservices.builder()
        .seeds(gateway.cluster().address())
        .services(new BenchmarkServiceImpl())
        .build()
        .startAwait();

    Flux.from(gateway.call().create().api(BenchmarkService.class)
        .requestMany(new BenchmarkMessage("hello joe", 1_000_000)))
        .blockLast();
    Thread.sleep(1000);

    ExecutorService exec = Executors.newFixedThreadPool(6);
    long both = System.currentTimeMillis();
    CompletableFuture.allOf(
        runClient(gateway, 1_000_000, exec),
        runClient(gateway, 1_000_000, exec),
        runClient(gateway, 1_000_000, exec),
        runClient(gateway, 1_000_000, exec),
        runClient(gateway, 1_000_000, exec),
        runClient(gateway, 1_000_000, exec))
        .get();
    long done = System.currentTimeMillis();
    System.out.println("requested : " + total + " :  at rate of(ms): " + (total.get() / (done - both)));
    exec.shutdownNow();
  }

  static AtomicInteger executerNumber = new AtomicInteger();

  static CompletableFuture<Void> runClient(Microservices gateway, int count, ExecutorService exec) {
    BenchmarkMessage request = new BenchmarkMessage("hello joe", count);
    total.addAndGet(count);
    return CompletableFuture.runAsync(() -> {
      int myExecutionNumber = executerNumber.incrementAndGet();
      System.out.println("### Task no." + myExecutionNumber + " request for(" + count + ")");
      long start = System.currentTimeMillis();
      Flux.from(gateway.call().create().api(BenchmarkService.class)
          .requestMany(request))
          .blockLast();
      long end = System.currentTimeMillis();
      System.out.println("request many " + myExecutionNumber + ": " + (end - start));
    }, exec);
  }
}

```