### PR TITLE
Add annotation AfterConstruct

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/annotations/AfterConstruct.java
+++ b/services-api/src/main/java/io/scalecube/services/annotations/AfterConstruct.java
@@ -1,0 +1,21 @@
+package io.scalecube.services.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark the method which will be executed after constructing of service and dependency
+ * injection is done.
+ * <p>
+ * Scalecube services doesn't support {@link javax.annotation.PostConstruct} since Java API Specification for it has
+ * strict limitation for annotated method.
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface AfterConstruct {
+}

--- a/services/src/main/java/io/scalecube/services/Reflect.java
+++ b/services/src/main/java/io/scalecube/services/Reflect.java
@@ -6,6 +6,7 @@ import static io.scalecube.services.CommunicationMode.REQUEST_RESPONSE;
 import static io.scalecube.services.CommunicationMode.REQUEST_STREAM;
 import static java.util.Objects.requireNonNull;
 
+import io.scalecube.services.annotations.AfterConstruct;
 import io.scalecube.services.annotations.Inject;
 import io.scalecube.services.annotations.Null;
 import io.scalecube.services.annotations.RequestType;
@@ -34,8 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import javax.annotation.PostConstruct;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -82,18 +81,18 @@ public class Reflect {
     private void inject(Collection<Object> collection) {
       for (Object instance : collection) {
         scanServiceFields(instance);
-        processPostConstruct(instance);
+        processAfterConstruct(instance);
       }
     }
 
-    private void processPostConstruct(Object targetInstance) {
+    private void processAfterConstruct(Object targetInstance) {
       Method[] declaredMethods = targetInstance.getClass().getDeclaredMethods();
       Arrays.stream(declaredMethods)
-          .filter(method -> method.isAnnotationPresent(PostConstruct.class))
-          .forEach(postConstructMethod -> {
+          .filter(method -> method.isAnnotationPresent(AfterConstruct.class))
+          .forEach(afterConstructMethod -> {
             try {
-              postConstructMethod.setAccessible(true);
-              Object[] paramters = Arrays.asList(postConstructMethod.getParameters()).stream().map(mapper -> {
+              afterConstructMethod.setAccessible(true);
+              Object[] parameters = Arrays.stream(afterConstructMethod.getParameters()).map(mapper -> {
                 if (mapper.getType().equals(Microservices.class)) {
                   return this.microservices;
                 } else if (isService(mapper.getType())) {
@@ -101,8 +100,8 @@ public class Reflect {
                 } else {
                   return null;
                 }
-              }).collect(Collectors.toList()).toArray();
-              postConstructMethod.invoke(targetInstance, paramters);
+              }).toArray();
+              afterConstructMethod.invoke(targetInstance, parameters);
             } catch (Exception ex) {
               throw new RuntimeException(ex);
             }


### PR DESCRIPTION
This annotation replacing usage of javax.annotation.PostConstruct in scalecube-services, because Java API Specification for javax.annotation.PostConstruct has strict criteria for the method

Fix #122 issue