### PR TITLE
add service registration events

### DIFF
--- a/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
@@ -2,25 +2,38 @@ package io.scalecube.services.registry.api;
 
 import io.scalecube.services.ServiceEndpoint;
 
+/**
+ * Service registration event. This event is being fired when {@link ServiceEndpoint} is being added (or removed from)
+ * to (from) {@link ServiceRegistry}.
+ */
 public class RegistrationEvent {
 
-  public enum RegistrationEventType {
-    REGISTERED, UNREGISTERED
+  public enum Type {
+    REGISTERED, // service endpoint added
+    UNREGISTERED // service endpoint removed
   }
 
-  private ServiceEndpoint serviceEndpoint;
-  private RegistrationEventType type;
+  private final ServiceEndpoint serviceEndpoint;
+  private final Type type;
 
-  public RegistrationEvent(RegistrationEventType type, ServiceEndpoint serviceEndpoint) {
+  private RegistrationEvent(Type type, ServiceEndpoint serviceEndpoint) {
     this.serviceEndpoint = serviceEndpoint;
     this.type = type;
+  }
+
+  public static RegistrationEvent registered(ServiceEndpoint serviceEndpoint) {
+    return new RegistrationEvent(Type.REGISTERED, serviceEndpoint);
+  }
+
+  public static RegistrationEvent unregistered(ServiceEndpoint serviceEndpoint) {
+    return new RegistrationEvent(Type.UNREGISTERED, serviceEndpoint);
   }
 
   public ServiceEndpoint serviceEndpoint() {
     return this.serviceEndpoint;
   }
 
-  public RegistrationEventType type() {
+  public Type type() {
     return this.type;
   }
 

--- a/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
@@ -4,14 +4,14 @@ import io.scalecube.services.ServiceEndpoint;
 
 public class RegistrationEvent {
 
-  public enum Type {
-    ADDED, REMOVED
+  public enum RegistrationEventType {
+    REGISTERED, UNREGISTERED
   }
 
   private ServiceEndpoint serviceEndpoint;
-  private Type type;
+  private RegistrationEventType type;
 
-  public RegistrationEvent(Type type, ServiceEndpoint serviceEndpoint) {
+  public RegistrationEvent(RegistrationEventType type, ServiceEndpoint serviceEndpoint) {
     this.serviceEndpoint = serviceEndpoint;
     this.type = type;
   }
@@ -20,7 +20,7 @@ public class RegistrationEvent {
     return this.serviceEndpoint;
   }
 
-  public Type type() {
+  public RegistrationEventType type() {
     return this.type;
   }
 

--- a/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/RegistrationEvent.java
@@ -1,0 +1,31 @@
+package io.scalecube.services.registry.api;
+
+import io.scalecube.services.ServiceEndpoint;
+
+public class RegistrationEvent {
+
+  public enum Type {
+    ADDED, REMOVED
+  }
+
+  private ServiceEndpoint serviceEndpoint;
+  private Type type;
+
+  public RegistrationEvent(Type type, ServiceEndpoint serviceEndpoint) {
+    this.serviceEndpoint = serviceEndpoint;
+    this.type = type;
+  }
+
+  public ServiceEndpoint serviceEndpoint() {
+    return this.serviceEndpoint;
+  }
+
+  public Type type() {
+    return this.type;
+  }
+
+  @Override
+  public String toString() {
+    return "RegistrationEvent [serviceEndpoint=" + serviceEndpoint + ", type=" + type + "]";
+  }
+}

--- a/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
@@ -3,6 +3,8 @@ package io.scalecube.services.registry.api;
 import io.scalecube.services.ServiceEndpoint;
 import io.scalecube.services.ServiceReference;
 
+import reactor.core.publisher.Flux;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -23,4 +25,6 @@ public interface ServiceRegistry {
   boolean registerService(ServiceEndpoint serviceEndpoint);
 
   ServiceEndpoint unregisterService(String endpointId);
+
+  Flux<RegistrationEvent> listen();
 }

--- a/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
@@ -3,11 +3,11 @@ package io.scalecube.services.registry.api;
 import io.scalecube.services.ServiceEndpoint;
 import io.scalecube.services.ServiceReference;
 
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Service registry interface provides API to register/unregister services in the system and make services lookup by
@@ -29,5 +29,5 @@ public interface ServiceRegistry {
 
   Flux<RegistrationEvent> listen();
 
-  public Mono<Void> shutdown();
+  Mono<Void> shutdown();
 }

--- a/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
+++ b/services-api/src/main/java/io/scalecube/services/registry/api/ServiceRegistry.java
@@ -4,6 +4,7 @@ import io.scalecube.services.ServiceEndpoint;
 import io.scalecube.services.ServiceReference;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -27,4 +28,6 @@ public interface ServiceRegistry {
   ServiceEndpoint unregisterService(String endpointId);
 
   Flux<RegistrationEvent> listen();
+
+  public Mono<Void> shutdown();
 }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -21,6 +21,8 @@ import io.scalecube.transport.Addressing;
 
 import com.codahale.metrics.MetricRegistry;
 
+import reactor.core.publisher.Mono;
+
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,8 +32,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import reactor.core.publisher.Mono;
 
 /**
  * The ScaleCube-Services module enables to provision and consuming microservices in a cluster. ScaleCube-Services
@@ -276,7 +276,7 @@ public class Microservices {
   }
 
   public Mono<Void> shutdown() {
-    return Mono.when(Mono.fromFuture(cluster.shutdown()), server.stop());
+    return Mono.when(Mono.fromFuture(cluster.shutdown()), server.stop(), serviceRegistry.shutdown());
   }
 
   public Cluster cluster() {

--- a/services/src/main/java/io/scalecube/services/discovery/ServiceDiscovery.java
+++ b/services/src/main/java/io/scalecube/services/discovery/ServiceDiscovery.java
@@ -74,7 +74,6 @@ public class ServiceDiscovery {
 
             LOGGER.info("Service Reference was REMOVED since Member have left the cluster {} : {}",
                 member, serviceEndpoint);
-
           }
         });
   }

--- a/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
@@ -10,7 +10,6 @@ import org.jctools.maps.NonBlockingHashMap;
 
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.ReplayProcessor;
 import reactor.core.scheduler.Schedulers;
 
 import java.util.ArrayList;

--- a/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/registry/ServiceRegistryImpl.java
@@ -3,7 +3,7 @@ package io.scalecube.services.registry;
 import io.scalecube.services.ServiceEndpoint;
 import io.scalecube.services.ServiceReference;
 import io.scalecube.services.registry.api.RegistrationEvent;
-import io.scalecube.services.registry.api.RegistrationEvent.Type;
+import io.scalecube.services.registry.api.RegistrationEvent.RegistrationEventType;
 import io.scalecube.services.registry.api.ServiceRegistry;
 
 import org.jctools.maps.NonBlockingHashMap;
@@ -75,7 +75,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
                   .computeIfAbsent(reference.qualifier(), k -> new CopyOnWriteArrayList<>())
                   .add(reference));
 
-      subject.onNext(new RegistrationEvent(Type.ADDED, serviceEndpoint));
+      subject.onNext(new RegistrationEvent(RegistrationEventType.REGISTERED, serviceEndpoint));
     }
     return success;
   }
@@ -85,7 +85,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
     ServiceEndpoint serviceEndpoint = serviceEndpoints.remove(endpointId);
     if (serviceEndpoint != null) {
       referencesByQualifier.values().forEach(list -> list.removeIf(sr -> sr.endpointId().equals(endpointId)));
-      subject.onNext(new RegistrationEvent(Type.REMOVED, serviceEndpoint));
+      subject.onNext(new RegistrationEvent(RegistrationEventType.UNREGISTERED, serviceEndpoint));
     }
     return serviceEndpoint;
   }
@@ -93,7 +93,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
   @Override
   public Flux<RegistrationEvent> listen() {
     return Flux.fromStream(serviceEndpoints.values().stream())
-        .map(serviceEndpoint->new RegistrationEvent(Type.ADDED, serviceEndpoint))
+        .map(serviceEndpoint->new RegistrationEvent(RegistrationEventType.REGISTERED, serviceEndpoint))
         .concatWith(subject)
         .publishOn(Schedulers.single());
   }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
@@ -1,7 +1,7 @@
 package io.scalecube.services;
 
-import static io.scalecube.services.registry.api.RegistrationEvent.RegistrationEventType.REGISTERED;
-import static io.scalecube.services.registry.api.RegistrationEvent.RegistrationEventType.UNREGISTERED;
+import static io.scalecube.services.registry.api.RegistrationEvent.Type.REGISTERED;
+import static io.scalecube.services.registry.api.RegistrationEvent.Type.UNREGISTERED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.scalecube.services.registry.api.RegistrationEvent;
@@ -9,13 +9,16 @@ import io.scalecube.services.sut.GreetingServiceImpl;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+
+import reactor.core.publisher.Mono;
 
 public class ServiceRegistryEventsTest {
 
   @Test
-  public void test_added_removed_registration_events() throws InterruptedException {
+  public void test_added_removed_registration_events() {
 
     List<RegistrationEvent> events = new ArrayList<>();
 
@@ -32,8 +35,7 @@ public class ServiceRegistryEventsTest {
         .services(new GreetingServiceImpl())
         .startAwait();
 
-    ms1.shutdown().block();
-    ms2.shutdown().block();
+    Mono.when(ms1.shutdown(), ms2.shutdown()).block(Duration.ofSeconds(6));
 
     assertEquals(4, events.size());
     assertEquals(REGISTERED, events.get(0).type());
@@ -41,5 +43,6 @@ public class ServiceRegistryEventsTest {
     assertEquals(UNREGISTERED, events.get(2).type());
     assertEquals(UNREGISTERED, events.get(3).type());
 
+    seed.shutdown().block(Duration.ofSeconds(6));
   }
 }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
@@ -1,7 +1,7 @@
 package io.scalecube.services;
 
-import static io.scalecube.services.registry.api.RegistrationEvent.Type.ADDED;
-import static io.scalecube.services.registry.api.RegistrationEvent.Type.REMOVED;
+import static io.scalecube.services.registry.api.RegistrationEvent.RegistrationEventType.REGISTERED;
+import static io.scalecube.services.registry.api.RegistrationEvent.RegistrationEventType.UNREGISTERED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.scalecube.services.registry.api.RegistrationEvent;
@@ -37,10 +37,10 @@ public class ServiceRegistryEventsTest {
 
     Thread.sleep(100);
     assertEquals(4, events.size());
-    assertEquals(ADDED, events.get(0).type());
-    assertEquals(ADDED, events.get(1).type());
-    assertEquals(REMOVED, events.get(2).type());
-    assertEquals(REMOVED, events.get(3).type());
+    assertEquals(REGISTERED, events.get(0).type());
+    assertEquals(REGISTERED, events.get(1).type());
+    assertEquals(UNREGISTERED, events.get(2).type());
+    assertEquals(UNREGISTERED, events.get(3).type());
 
   }
 }

--- a/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
@@ -1,0 +1,46 @@
+package io.scalecube.services;
+
+import static io.scalecube.services.registry.api.RegistrationEvent.Type.ADDED;
+import static io.scalecube.services.registry.api.RegistrationEvent.Type.REMOVED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.scalecube.services.registry.api.RegistrationEvent;
+import io.scalecube.services.sut.GreetingServiceImpl;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ServiceRegistryEventsTest {
+
+  @Test
+  public void test_added_removed_registration_events() throws InterruptedException {
+
+    List<RegistrationEvent> events = new ArrayList<>();
+    
+    Microservices seed = Microservices.builder()
+        .startAwait();
+
+    seed.serviceRegistry().listen().subscribe(events::add);
+
+    Microservices ms1 = Microservices.builder().seeds(seed.cluster().address())
+        .services(new GreetingServiceImpl())
+        .startAwait();
+
+    Microservices ms2 = Microservices.builder().seeds(seed.cluster().address())
+        .services(new GreetingServiceImpl())
+        .startAwait();
+
+    ms1.shutdown().block();
+    ms2.shutdown().block();
+
+    Thread.sleep(100);
+    assertEquals(4, events.size());
+    assertEquals(ADDED, events.get(0).type());
+    assertEquals(ADDED, events.get(1).type());
+    assertEquals(REMOVED, events.get(2).type());
+    assertEquals(REMOVED, events.get(3).type());
+
+  }
+}

--- a/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceRegistryEventsTest.java
@@ -18,7 +18,7 @@ public class ServiceRegistryEventsTest {
   public void test_added_removed_registration_events() throws InterruptedException {
 
     List<RegistrationEvent> events = new ArrayList<>();
-    
+
     Microservices seed = Microservices.builder()
         .startAwait();
 
@@ -35,7 +35,6 @@ public class ServiceRegistryEventsTest {
     ms1.shutdown().block();
     ms2.shutdown().block();
 
-    Thread.sleep(100);
     assertEquals(4, events.size());
     assertEquals(REGISTERED, events.get(0).type());
     assertEquals(REGISTERED, events.get(1).type());


### PR DESCRIPTION
Motivation

allow users to listen on service endpoint been added and removed this info might be interesting for allowing to react on such events (tracing, monitoring reasons).

```java

    microservices
      .serviceRegistry().listen()
         .subscribe(event->{
                
               //<.....doing something with the event....>

         });

``` 